### PR TITLE
feat: #13 프론트 localhost에서 호출시 CORS 가능하도록 추가

### DIFF
--- a/src/main/java/com/example/dnd_13th_9_be/config/WebConfig.java
+++ b/src/main/java/com/example/dnd_13th_9_be/config/WebConfig.java
@@ -1,0 +1,18 @@
+package com.example.dnd_13th_9_be.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+  @Override
+  public void addCorsMappings(CorsRegistry registry) {
+    registry
+        .addMapping("/**")
+        .allowedOrigins("http://localhost:3000")
+        .allowedMethods("GET", "POST")
+        .allowCredentials(true);
+  }
+}


### PR DESCRIPTION
### Changes 📝
- 프론트 localhost에서 API 호출시 CORS 가능하도록 WebConfig를 추가했습니다

### to 리뷰어
- 프론트 배포 후 ip가 정해지면 수정이 필요합니다

### Screenshot 📷

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled cross-origin requests from http://localhost:3000, supporting only GET and POST methods and allowing credentials for these requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->