### PR TITLE
[CHORE] common api response global exception

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 	testAnnotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 
 	// Swagger
-	implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0"
+	implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0"
 }
 
 spotless {

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ dependencies {
 	testAnnotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
 	testAnnotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 	testAnnotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
+	// Swagger
+	implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0"
 }
 
 spotless {

--- a/src/main/java/com/example/dnd_13th_9_be/config/OpenApiConfig.java
+++ b/src/main/java/com/example/dnd_13th_9_be/config/OpenApiConfig.java
@@ -1,0 +1,18 @@
+package com.example.dnd_13th_9_be.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+
+@Configuration
+public class OpenApiConfig {
+  @Bean
+  public OpenAPI openAPI() {
+    Info info = new Info().title("zip.zip").version("v0.0.1").description("zip.zip 의 API 문서입니다.");
+
+    return new OpenAPI().components(new Components()).info(info);
+  }
+}

--- a/src/main/java/com/example/dnd_13th_9_be/global/error/BusinessException.java
+++ b/src/main/java/com/example/dnd_13th_9_be/global/error/BusinessException.java
@@ -1,0 +1,19 @@
+package com.example.dnd_13th_9_be.global.error;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+  private final ErrorCode errorCode;
+
+  public BusinessException(ErrorCode errorCode) {
+    super(errorCode.defaultMessage());
+    this.errorCode = errorCode;
+  }
+
+  public BusinessException(ErrorCode errorCode, String message) {
+    super(message);
+    this.errorCode = errorCode;
+  }
+}

--- a/src/main/java/com/example/dnd_13th_9_be/global/error/ErrorCode.java
+++ b/src/main/java/com/example/dnd_13th_9_be/global/error/ErrorCode.java
@@ -11,12 +11,12 @@ import com.example.dnd_13th_9_be.global.response.ResponseCode;
 public enum ErrorCode implements ResponseCode {
   // client error
   BAD_REQUEST(HttpStatus.BAD_REQUEST, "40000", "요청이 올바르지 않습니다"),
-  VALIDATION_ERROR(HttpStatus.UNPROCESSABLE_ENTITY, "40001", "검증 오류가 발생했습니다"),
-  NOT_FOUND(HttpStatus.NOT_FOUND, "40001", "대상을 찾을 수 없습니다"),
+  VALIDATION_ERROR(HttpStatus.UNPROCESSABLE_ENTITY, "42200", "검증 오류가 발생했습니다"),
+  NOT_FOUND(HttpStatus.NOT_FOUND, "40400", "대상을 찾을 수 없습니다"),
 
   // server error
   INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "50000", "서버 내부 오류입니다"),
-  SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "50001", "일시적으로 이용할 수 없습니다"),
+  SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "50300", "일시적으로 이용할 수 없습니다"),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/example/dnd_13th_9_be/global/error/ErrorCode.java
+++ b/src/main/java/com/example/dnd_13th_9_be/global/error/ErrorCode.java
@@ -1,0 +1,40 @@
+package com.example.dnd_13th_9_be.global.error;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+import com.example.dnd_13th_9_be.global.response.ResponseCode;
+
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public enum ErrorCode implements ResponseCode {
+  // client error
+  BAD_REQUEST(HttpStatus.BAD_REQUEST, "40000", "요청이 올바르지 않습니다"),
+  VALIDATION_ERROR(HttpStatus.UNPROCESSABLE_ENTITY, "40001", "검증 오류가 발생했습니다"),
+  NOT_FOUND(HttpStatus.NOT_FOUND, "40001", "대상을 찾을 수 없습니다"),
+
+  // server error
+  INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "50000", "서버 내부 오류입니다"),
+  SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "50001", "일시적으로 이용할 수 없습니다"),
+  ;
+
+  private final HttpStatus status;
+  private final String code;
+  private final String message;
+
+  @Override
+  public HttpStatus httpStatus() {
+    return status;
+  }
+
+  @Override
+  public String code() {
+    return code;
+  }
+
+  @Override
+  public String defaultMessage() {
+    return message;
+  }
+}

--- a/src/main/java/com/example/dnd_13th_9_be/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/dnd_13th_9_be/global/error/GlobalExceptionHandler.java
@@ -14,8 +14,10 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import lombok.extern.slf4j.Slf4j;
 
 import com.example.dnd_13th_9_be.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 
 @Slf4j
+@Hidden
 @RestControllerAdvice
 public class GlobalExceptionHandler {
   @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/src/main/java/com/example/dnd_13th_9_be/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/dnd_13th_9_be/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,66 @@
+package com.example.dnd_13th_9_be.global.error;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import lombok.extern.slf4j.Slf4j;
+
+import com.example.dnd_13th_9_be.global.response.ApiResponse;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ApiResponse<Map<String, String>>> handleValidation(
+      MethodArgumentNotValidException ex) {
+    log.warn(ex.getMessage(), ex);
+    Map<String, String> fieldErrors = new LinkedHashMap<>();
+    ex.getBindingResult()
+        .getFieldErrors()
+        .forEach(
+            fe -> {
+              fieldErrors.put(fe.getField(), fe.getDefaultMessage());
+            });
+    return ApiResponse.entity(ErrorCode.VALIDATION_ERROR, fieldErrors);
+  }
+
+  @ExceptionHandler(BindException.class)
+  public ResponseEntity<ApiResponse<Map<String, String>>> handleBind(BindException ex) {
+    log.warn(ex.getMessage(), ex);
+    Map<String, String> fieldErrors = new LinkedHashMap<>();
+    ex.getFieldErrors().forEach(fe -> fieldErrors.put(fe.getField(), fe.getDefaultMessage()));
+    return ApiResponse.entity(ErrorCode.VALIDATION_ERROR, fieldErrors);
+  }
+
+  @ExceptionHandler(ConstraintViolationException.class)
+  public ResponseEntity<ApiResponse<Map<String, String>>> handleConstraintViolation(
+      ConstraintViolationException ex) {
+    log.warn(ex.getMessage(), ex);
+    Map<String, String> fieldErrors = new LinkedHashMap<>();
+    for (ConstraintViolation<?> v : ex.getConstraintViolations()) {
+      fieldErrors.put(
+          v.getPropertyPath().toString(), v.getMessage() != null ? v.getMessage() : "invalid");
+    }
+    return ApiResponse.entity(ErrorCode.VALIDATION_ERROR, fieldErrors);
+  }
+
+  @ExceptionHandler(BusinessException.class)
+  public ResponseEntity<ApiResponse<Void>> handleBusiness(BusinessException ex) {
+    log.warn(ex.getMessage(), ex);
+    return ApiResponse.errorEntity(ex.getErrorCode());
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ApiResponse<Void>> handleGeneric(Exception ex) {
+    log.error(ex.getMessage(), ex);
+    return ApiResponse.errorEntity(ErrorCode.INTERNAL_ERROR);
+  }
+}

--- a/src/main/java/com/example/dnd_13th_9_be/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/dnd_13th_9_be/global/error/GlobalExceptionHandler.java
@@ -7,7 +7,6 @@ import jakarta.validation.ConstraintViolationException;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 

--- a/src/main/java/com/example/dnd_13th_9_be/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/dnd_13th_9_be/global/error/GlobalExceptionHandler.java
@@ -20,20 +20,6 @@ import io.swagger.v3.oas.annotations.Hidden;
 @Hidden
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-  @ExceptionHandler(MethodArgumentNotValidException.class)
-  public ResponseEntity<ApiResponse<Map<String, String>>> handleValidation(
-      MethodArgumentNotValidException ex) {
-    log.warn(ex.getMessage(), ex);
-    Map<String, String> fieldErrors = new LinkedHashMap<>();
-    ex.getBindingResult()
-        .getFieldErrors()
-        .forEach(
-            fe -> {
-              fieldErrors.put(fe.getField(), fe.getDefaultMessage());
-            });
-    return ApiResponse.entity(ErrorCode.VALIDATION_ERROR, fieldErrors);
-  }
-
   @ExceptionHandler(BindException.class)
   public ResponseEntity<ApiResponse<Map<String, String>>> handleBind(BindException ex) {
     log.warn(ex.getMessage(), ex);
@@ -56,6 +42,8 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(BusinessException.class)
   public ResponseEntity<ApiResponse<Void>> handleBusiness(BusinessException ex) {
+    // BusinessException의 message는 디버깅을 위한 로깅으로 사용되며
+    // 클라이언트는 message를 보는 것이 아닌 ErrorCode의 message를 전달 받습니다
     log.warn(ex.getMessage(), ex);
     return ApiResponse.errorEntity(ex.getErrorCode());
   }

--- a/src/main/java/com/example/dnd_13th_9_be/global/response/ApiResponse.java
+++ b/src/main/java/com/example/dnd_13th_9_be/global/response/ApiResponse.java
@@ -22,7 +22,7 @@ public class ApiResponse<T> {
     this.data = data;
   }
 
-  public static ApiResponse<Map<Object, Object>> ok() {
+  public static ApiResponse<Map<String, Object>> ok() {
     return success(Map.of());
   }
 
@@ -38,7 +38,7 @@ public class ApiResponse<T> {
     return new ApiResponse<>(code.code(), code.defaultMessage(), data);
   }
 
-  public static ResponseEntity<ApiResponse<Map<Object, Object>>> okEntity() {
+  public static ResponseEntity<ApiResponse<Map<String, Object>>> okEntity() {
     return ResponseEntity.ok(ok());
   }
 

--- a/src/main/java/com/example/dnd_13th_9_be/global/response/ApiResponse.java
+++ b/src/main/java/com/example/dnd_13th_9_be/global/response/ApiResponse.java
@@ -43,7 +43,7 @@ public class ApiResponse<T> {
   }
 
   public static <T> ResponseEntity<ApiResponse<T>> successEntity(T data) {
-    return ResponseEntity.status(SuccessCode.SUCCESS.httpStatus()).body(ApiResponse.success(data));
+    return ResponseEntity.ok(ApiResponse.success(data));
   }
 
   public static <T> ResponseEntity<ApiResponse<T>> errorEntity(ErrorCode code) {

--- a/src/main/java/com/example/dnd_13th_9_be/global/response/ApiResponse.java
+++ b/src/main/java/com/example/dnd_13th_9_be/global/response/ApiResponse.java
@@ -1,0 +1,56 @@
+package com.example.dnd_13th_9_be.global.response;
+
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+
+import lombok.Getter;
+
+import com.example.dnd_13th_9_be.global.error.ErrorCode;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@Getter
+@JsonPropertyOrder({"code", "message", "data"})
+public class ApiResponse<T> {
+  private final String code;
+  private final String message;
+  private final T data;
+
+  private ApiResponse(String code, String message, T data) {
+    this.code = code;
+    this.message = message;
+    this.data = data;
+  }
+
+  public static ApiResponse<Map<Object, Object>> ok() {
+    return success(Map.of());
+  }
+
+  public static <T> ApiResponse<T> success(T data) {
+    return of(SuccessCode.SUCCESS, data);
+  }
+
+  public static <T> ApiResponse<T> error(ErrorCode code) {
+    return of(code, null);
+  }
+
+  public static <T> ApiResponse<T> of(ResponseCode code, T data) {
+    return new ApiResponse<>(code.code(), code.defaultMessage(), data);
+  }
+
+  public static ResponseEntity<ApiResponse<Map<Object, Object>>> okEntity() {
+    return ResponseEntity.ok(ok());
+  }
+
+  public static <T> ResponseEntity<ApiResponse<T>> successEntity(T data) {
+    return ResponseEntity.status(SuccessCode.SUCCESS.httpStatus()).body(ApiResponse.success(data));
+  }
+
+  public static <T> ResponseEntity<ApiResponse<T>> errorEntity(ErrorCode code) {
+    return ResponseEntity.status(code.httpStatus()).body(error(code));
+  }
+
+  public static <T> ResponseEntity<ApiResponse<T>> entity(ResponseCode code, T data) {
+    return ResponseEntity.status(code.httpStatus()).body(ApiResponse.of(code, data));
+  }
+}

--- a/src/main/java/com/example/dnd_13th_9_be/global/response/ResponseCode.java
+++ b/src/main/java/com/example/dnd_13th_9_be/global/response/ResponseCode.java
@@ -1,0 +1,11 @@
+package com.example.dnd_13th_9_be.global.response;
+
+import org.springframework.http.HttpStatus;
+
+public interface ResponseCode {
+  HttpStatus httpStatus();
+
+  String code();
+
+  String defaultMessage();
+}

--- a/src/main/java/com/example/dnd_13th_9_be/global/response/SuccessCode.java
+++ b/src/main/java/com/example/dnd_13th_9_be/global/response/SuccessCode.java
@@ -7,8 +7,8 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public enum SuccessCode implements ResponseCode {
-  SUCCESS(HttpStatus.OK, "00000", "성공했습니다"),
-  CREATED(HttpStatus.CREATED, "00001", "생성되었습니다"),
+  SUCCESS(HttpStatus.OK, "20000", "성공했습니다"),
+  CREATED(HttpStatus.CREATED, "20100", "생성되었습니다"),
   ;
 
   private final HttpStatus status;

--- a/src/main/java/com/example/dnd_13th_9_be/global/response/SuccessCode.java
+++ b/src/main/java/com/example/dnd_13th_9_be/global/response/SuccessCode.java
@@ -1,0 +1,32 @@
+package com.example.dnd_13th_9_be.global.response;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public enum SuccessCode implements ResponseCode {
+  SUCCESS(HttpStatus.OK, "00000", "성공했습니다"),
+  CREATED(HttpStatus.CREATED, "00001", "생성되었습니다"),
+  ;
+
+  private final HttpStatus status;
+  private final String code;
+  private final String message;
+
+  @Override
+  public HttpStatus httpStatus() {
+    return status;
+  }
+
+  @Override
+  public String code() {
+    return code;
+  }
+
+  @Override
+  public String defaultMessage() {
+    return message;
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,3 +3,19 @@ spring:
     name: DND_13th_9_BE
   profiles:
     active: dev
+
+# Swagger springdoc-ui Configuration
+springdoc:
+  packages-to-scan: com.example.dnd_13th_9_be
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  cache:
+    disabled: true
+  api-docs:
+    path: /api-docs
+    groups:
+      enabled: true
+  swagger-ui:
+    path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: alpha


### PR DESCRIPTION
### Changes 📝
- 패키지 전역에서 사용할 수 있는 ApiResponse 응답 클래스를 추가했습니다. 클라이언트 파싱 처리를 위해 모든 API의 응답을 통일화 했습니다. 논의된 내용은 to리뷰어 항목에서 확인할 수 있습니다
- ResponseCode로 발생할 수 있는 응답 유형에 대한 코드와 메세지를 작성했습니다
- @RestControllerAdvice를 도입하여 글로벌 예외 표준화
- 비즈니스 규칙 위반시 BussinessException을 사용할 수 있게 추가해 두었습니다
- Swagger UI 설정을 추가했습니다

### to 리뷰어
- ResponseCode에서 사용하는 code 형식 정의에 대해 논의가 필요합니다
- 프론트와 논의된 내용을 코드 블럭에 정리해서 전달드립니다. 내용 확인하시고 코드리뷰에 참고해주세요!
```text
- 에러 응답과 성공 응답 모두 동일한 구조 (code, message, data)
- 에러 응답에서 필드 유효성 검사 실패 항목은 data로 전달
- 에러 응답에서 별도의 data가 없는 경우 null
- 성공 응답에서 별도의 data가 없는 경우 빈 객체 {}
```
- HandlerMethodValidationException 처리가 아직 안되어 있어 작업이 필요합니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced standardized API response structures for all endpoints.
  * Added centralized error handling for validation, business, and generic exceptions, providing clear error messages.
  * Integrated OpenAPI (Swagger) documentation with a user-friendly UI for exploring and testing REST APIs.

* **Chores**
  * Updated build configuration and application settings to support validation and API documentation features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->