### PR TITLE
[FEAT] 사용자 생성시 기본 폴더, 기본 계획 생성

### DIFF
--- a/src/main/java/com/example/dnd_13th_9_be/folder/application/FolderService.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/application/FolderService.java
@@ -27,6 +27,11 @@ public class FolderService {
   private final FolderCommandPort folderCommandPort;
   private final PlanAccessPort planAccessPort;
 
+  @Transactional
+  public FolderDetailResult createDefaultFolder(Long planId) {
+    return folderCommandPort.create(planId, "기본 폴더", true);
+  }
+
   @Transactional(readOnly = true)
   public List<FolderSummaryResult> getFolderList(Long planId) {
     verifyPlanExists(planId);

--- a/src/main/java/com/example/dnd_13th_9_be/folder/application/FolderService.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/application/FolderService.java
@@ -27,9 +27,11 @@ public class FolderService {
   private final FolderCommandPort folderCommandPort;
   private final PlanAccessPort planAccessPort;
 
+  private static final String DEFAULT_FOLDER_NAME = "기본 폴더";
+
   @Transactional
-  public FolderDetailResult createDefaultFolder(Long planId) {
-    return folderCommandPort.create(planId, "기본 폴더", true);
+  public void createDefaultFolder(Long planId) {
+    folderCommandPort.create(planId, DEFAULT_FOLDER_NAME, true);
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/com/example/dnd_13th_9_be/plan/application/PlanService.java
+++ b/src/main/java/com/example/dnd_13th_9_be/plan/application/PlanService.java
@@ -24,9 +24,11 @@ public class PlanService {
   private final PlanQueryPort planQueryPort;
   private final PlanCommandPort planCommandPort;
 
+  private static final String DEFAULT_PLAN_NAME = "기본 계획";
+
   @Transactional
   public PlanDetailResult createDefaultPlan(Long userId) {
-    return planCommandPort.create(userId, "기본 계획", true);
+    return planCommandPort.create(userId, DEFAULT_PLAN_NAME, true);
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/com/example/dnd_13th_9_be/plan/application/PlanService.java
+++ b/src/main/java/com/example/dnd_13th_9_be/plan/application/PlanService.java
@@ -24,6 +24,11 @@ public class PlanService {
   private final PlanQueryPort planQueryPort;
   private final PlanCommandPort planCommandPort;
 
+  @Transactional
+  public PlanDetailResult createDefaultPlan(Long userId) {
+    return planCommandPort.create(userId, "기본 계획", true);
+  }
+
   @Transactional(readOnly = true)
   public List<PlanSummaryResult> getPlanList(Long userId) {
     return planQueryPort.findSummariesByUserId(userId);

--- a/src/main/java/com/example/dnd_13th_9_be/plan/persistence/entity/PlanEntity.java
+++ b/src/main/java/com/example/dnd_13th_9_be/plan/persistence/entity/PlanEntity.java
@@ -14,7 +14,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -28,12 +27,7 @@ import org.hibernate.annotations.Comment;
 import org.hibernate.annotations.CreationTimestamp;
 
 @Entity
-@Table(
-    name = "plan",
-    uniqueConstraints =
-        @UniqueConstraint(
-            name = "uk_plan_user_default",
-            columnNames = {"user_id", "default_yn"}))
+@Table(name = "plan")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PlanEntity {

--- a/src/main/java/com/example/dnd_13th_9_be/plan/persistence/entity/PlanEntity.java
+++ b/src/main/java/com/example/dnd_13th_9_be/plan/persistence/entity/PlanEntity.java
@@ -14,6 +14,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -27,7 +28,12 @@ import org.hibernate.annotations.Comment;
 import org.hibernate.annotations.CreationTimestamp;
 
 @Entity
-@Table(name = "plan")
+@Table(
+    name = "plan",
+    uniqueConstraints =
+        @UniqueConstraint(
+            name = "uk_plan_user_default",
+            columnNames = {"user_id", "default_yn"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PlanEntity {

--- a/src/main/java/com/example/dnd_13th_9_be/user/application/service/CustomOauth2UserService.java
+++ b/src/main/java/com/example/dnd_13th_9_be/user/application/service/CustomOauth2UserService.java
@@ -14,6 +14,9 @@ import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import com.example.dnd_13th_9_be.folder.application.FolderService;
+import com.example.dnd_13th_9_be.plan.application.PlanService;
+import com.example.dnd_13th_9_be.plan.application.dto.PlanDetailResult;
 import com.example.dnd_13th_9_be.user.application.dto.KakaoAttribute;
 import com.example.dnd_13th_9_be.user.application.dto.OAuth2Attribute;
 import com.example.dnd_13th_9_be.user.application.dto.RoleAttribute;
@@ -26,6 +29,8 @@ import com.example.dnd_13th_9_be.user.application.repository.UserRepository;
 public class CustomOauth2UserService extends DefaultOAuth2UserService {
 
   private final UserRepository userRepository;
+  private final PlanService planService;
+  private final FolderService folderService;
 
   @Override
   public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -79,6 +84,8 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
 
                 UserModel savedUser = userRepository.save(newUser);
                 log.info("신규 사용자 생성 완료 - providerId: {}, ID: {}", providerId, savedUser.getId());
+                PlanDetailResult plan = planService.createDefaultPlan(savedUser.getId());
+                folderService.createDefaultFolder(plan.planId());
                 return savedUser;
 
               } catch (Exception e) {


### PR DESCRIPTION
## 작업내용
closes #29 
- 사용자 생성 시 기본 폴더와 기본 계획이 생성되도록 작업했습니다

## 리뷰어 공유사항
- 기존에 작업해 두셨던 CustomOauth2UserService에 해당 로직을 추가했습니다 

## Screenshot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New users now receive an automatically created default plan and a default folder (inside that plan) on first sign-in.
  * Defaults appear in your plans and folders lists and can be renamed or modified like any other items.
  * Applies to new sign-ins; existing users are unaffected.

* **Chores**
  * Database now enforces at-most-one default plan per user to ensure consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->