### PR TITLE
hotfix : https 에 따른 쿠키 설정

### DIFF
--- a/src/main/java/com/example/dnd_13th_9_be/common/utils/CookieUtil.java
+++ b/src/main/java/com/example/dnd_13th_9_be/common/utils/CookieUtil.java
@@ -18,7 +18,8 @@ public class CookieUtil {
     cookie.setMaxAge((int) (expirationMs / 1000)); // 초 단위로 변환
     cookie.setPath("/");
     cookie.setHttpOnly(true);
-    cookie.setSecure(false); // TODO: https 적용후 true
+    cookie.setSecure(true); // TODO: https 적용후 true
+    cookie.setAttribute("SameSite", "None");
     return cookie;
   }
 
@@ -27,7 +28,8 @@ public class CookieUtil {
     cookie.setMaxAge(0);
     cookie.setPath("/");
     cookie.setHttpOnly(true);
-    cookie.setSecure(false); // TODO: https 적용후 true
+    cookie.setSecure(true); // TODO: https 적용후 true
+    cookie.setAttribute("SameSite", "None");
     return cookie;
   }
 

--- a/src/main/java/com/example/dnd_13th_9_be/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/dnd_13th_9_be/config/security/SecurityConfig.java
@@ -100,6 +100,7 @@ public class SecurityConfig {
             .allowedOriginPatterns("http://localhost:3000", "https://zipzip-home.vercel.app")
             .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
             .allowCredentials(true)
+            .allowedHeaders("*")
             .exposedHeaders("Set-Cookie")
             .maxAge(3600);
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session reliability across sites by sending cookies only over HTTPS and enabling cross-site cookie usage (SameSite=None).
  * Resolved CORS issues with custom request headers by allowing all headers in cross-origin requests; existing origins, methods, credentials, and exposed headers remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->