### PR TITLE
fix : 쿠키 도메인 허용

### DIFF
--- a/src/main/java/com/example/dnd_13th_9_be/common/utils/CookieUtil.java
+++ b/src/main/java/com/example/dnd_13th_9_be/common/utils/CookieUtil.java
@@ -20,7 +20,7 @@ public class CookieUtil {
     cookie.setHttpOnly(false);
     cookie.setSecure(true); // TODO: https 적용후 true
     cookie.setAttribute("SameSite", "None");
-    cookie.setDomain(".zipzip.cloud");
+    cookie.setDomain("zipzip.cloud");
     return cookie;
   }
 
@@ -31,7 +31,7 @@ public class CookieUtil {
     cookie.setHttpOnly(false);
     cookie.setSecure(true); // TODO: https 적용후 true
     cookie.setAttribute("SameSite", "None");
-    cookie.setDomain(".zipzip.cloud");
+    cookie.setDomain("zipzip.cloud");
     return cookie;
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Updated cookie domain to zipzip.cloud for session cookies. This ensures correct setting, retrieval, and removal across the site, improving sign-in persistence, logout reliability, and navigation stability. Other cookie attributes remain unchanged, preserving existing behavior while aligning domain scoping for consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->