### PR TITLE
[FEAT] 매물 메모 리스트 조회 API

### DIFF
--- a/src/main/java/com/example/dnd_13th_9_be/config/QuerydslConfig.java
+++ b/src/main/java/com/example/dnd_13th_9_be/config/QuerydslConfig.java
@@ -1,5 +1,6 @@
 package com.example.dnd_13th_9_be.config;
 
+import com.querydsl.jpa.JPQLTemplates;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 
@@ -15,6 +16,6 @@ public class QuerydslConfig {
 
   @Bean
   public JPAQueryFactory jpaQueryFactory() {
-    return new JPAQueryFactory(em);
+    return new JPAQueryFactory(JPQLTemplates.DEFAULT, em);
   }
 }

--- a/src/main/java/com/example/dnd_13th_9_be/config/QuerydslConfig.java
+++ b/src/main/java/com/example/dnd_13th_9_be/config/QuerydslConfig.java
@@ -1,12 +1,12 @@
 package com.example.dnd_13th_9_be.config;
 
-import com.querydsl.jpa.JPQLTemplates;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.querydsl.jpa.JPQLTemplates;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 @Configuration

--- a/src/main/java/com/example/dnd_13th_9_be/folder/application/FolderService.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/application/FolderService.java
@@ -1,6 +1,5 @@
 package com.example.dnd_13th_9_be.folder.application;
 
-import com.example.dnd_13th_9_be.folder.application.dto.RecordSummaryResult;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -10,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 
 import com.example.dnd_13th_9_be.folder.application.dto.FolderDetailResult;
 import com.example.dnd_13th_9_be.folder.application.dto.FolderSummaryResult;
+import com.example.dnd_13th_9_be.folder.application.dto.RecordSummaryResult;
 import com.example.dnd_13th_9_be.folder.application.repository.FolderRepository;
 import com.example.dnd_13th_9_be.global.error.BusinessException;
 import com.example.dnd_13th_9_be.plan.application.repository.PlanRepository;

--- a/src/main/java/com/example/dnd_13th_9_be/folder/application/FolderService.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/application/FolderService.java
@@ -1,5 +1,6 @@
 package com.example.dnd_13th_9_be.folder.application;
 
+import com.example.dnd_13th_9_be.folder.application.dto.RecordSummaryResult;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -69,5 +70,10 @@ public class FolderService {
     if (isFailDelete) {
       throw new BusinessException(FOLDER_DELETE_FAILED);
     }
+  }
+
+  public List<RecordSummaryResult> getRecordList(Long userId, Long folderId) {
+    folderRepository.verifyById(userId, folderId);
+    return folderRepository.findAllRecordByIdAndUserId(userId, folderId);
   }
 }

--- a/src/main/java/com/example/dnd_13th_9_be/folder/application/dto/RecordSummaryResult.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/application/dto/RecordSummaryResult.java
@@ -1,12 +1,14 @@
 package com.example.dnd_13th_9_be.folder.application.dto;
 
-import com.example.dnd_13th_9_be.folder.persistence.dto.RecordSummary;
-import com.example.dnd_13th_9_be.folder.persistence.dto.RecordSummary.RecordImageSummary;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Optional;
+
 import lombok.Builder;
+
+import com.example.dnd_13th_9_be.folder.persistence.dto.RecordSummary;
+import com.example.dnd_13th_9_be.folder.persistence.dto.RecordSummary.RecordImageSummary;
 
 @Builder
 public record RecordSummaryResult(
@@ -23,31 +25,28 @@ public record RecordSummaryResult(
     String locationTag,
     Double latitude,
     Double longitude,
-    LocalDateTime createdAt
-) {
-    public static RecordSummaryResult from(RecordSummary recordSummary) {
-        RecordImageSummary image =
-            Optional.ofNullable(recordSummary.images())
-                .orElseGet(Collections::emptyList)
-                .stream()
-                .filter(i -> Objects.equals(i.order(), 1))
-                .findFirst()
-                .orElse(null);
-        return RecordSummaryResult.builder()
-            .id(recordSummary.id())
-            .imageUrl(image == null ? null : image.url())
-            .recordType(recordSummary.recordType().name())
-            .feeling(recordSummary.feeling().name())
-            .title(recordSummary.title())
-            .contractType(recordSummary.contractType().name())
-            .depositBig(recordSummary.depositBig())
-            .depositSmall(recordSummary.depositSmall())
-            .managementFee(recordSummary.managementFee())
-            .memo(recordSummary.memo())
-            .locationTag(recordSummary.locationTag())
-            .latitude(recordSummary.latitude())
-            .longitude(recordSummary.longitude())
-            .createdAt(recordSummary.createdAt().toLocalDateTime())
-            .build();
-    }
+    LocalDateTime createdAt) {
+  public static RecordSummaryResult from(RecordSummary recordSummary) {
+    RecordImageSummary image =
+        Optional.ofNullable(recordSummary.images()).orElseGet(Collections::emptyList).stream()
+            .filter(i -> Objects.equals(i.order(), 1))
+            .findFirst()
+            .orElse(null);
+    return RecordSummaryResult.builder()
+        .id(recordSummary.id())
+        .imageUrl(image == null ? null : image.url())
+        .recordType(recordSummary.recordType().name())
+        .feeling(recordSummary.feeling().name())
+        .title(recordSummary.title())
+        .contractType(recordSummary.contractType().name())
+        .depositBig(recordSummary.depositBig())
+        .depositSmall(recordSummary.depositSmall())
+        .managementFee(recordSummary.managementFee())
+        .memo(recordSummary.memo())
+        .locationTag(recordSummary.locationTag())
+        .latitude(recordSummary.latitude())
+        .longitude(recordSummary.longitude())
+        .createdAt(recordSummary.createdAt().toLocalDateTime())
+        .build();
+  }
 }

--- a/src/main/java/com/example/dnd_13th_9_be/folder/application/dto/RecordSummaryResult.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/application/dto/RecordSummaryResult.java
@@ -1,0 +1,53 @@
+package com.example.dnd_13th_9_be.folder.application.dto;
+
+import com.example.dnd_13th_9_be.folder.persistence.dto.RecordSummary;
+import com.example.dnd_13th_9_be.folder.persistence.dto.RecordSummary.RecordImageSummary;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.Builder;
+
+@Builder
+public record RecordSummaryResult(
+    Long id,
+    String imageUrl,
+    String recordType,
+    String feeling,
+    String title,
+    String contractType,
+    Integer depositBig,
+    Integer depositSmall,
+    Integer managementFee,
+    String memo,
+    String locationTag,
+    Double latitude,
+    Double longitude,
+    LocalDateTime createdAt
+) {
+    public static RecordSummaryResult from(RecordSummary recordSummary) {
+        RecordImageSummary image =
+            Optional.ofNullable(recordSummary.images())
+                .orElseGet(Collections::emptyList)
+                .stream()
+                .filter(i -> Objects.equals(i.order(), 1))
+                .findFirst()
+                .orElse(null);
+        return RecordSummaryResult.builder()
+            .id(recordSummary.id())
+            .imageUrl(image == null ? null : image.url())
+            .recordType(recordSummary.recordType().name())
+            .feeling(recordSummary.feeling().name())
+            .title(recordSummary.title())
+            .contractType(recordSummary.contractType().name())
+            .depositBig(recordSummary.depositBig())
+            .depositSmall(recordSummary.depositSmall())
+            .managementFee(recordSummary.managementFee())
+            .memo(recordSummary.memo())
+            .locationTag(recordSummary.locationTag())
+            .latitude(recordSummary.latitude())
+            .longitude(recordSummary.longitude())
+            .createdAt(recordSummary.createdAt().toLocalDateTime())
+            .build();
+    }
+}

--- a/src/main/java/com/example/dnd_13th_9_be/folder/application/repository/FolderRepository.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/application/repository/FolderRepository.java
@@ -1,10 +1,10 @@
 package com.example.dnd_13th_9_be.folder.application.repository;
 
-import com.example.dnd_13th_9_be.folder.application.dto.RecordSummaryResult;
 import java.util.List;
 
 import com.example.dnd_13th_9_be.folder.application.dto.FolderDetailResult;
 import com.example.dnd_13th_9_be.folder.application.dto.FolderSummaryResult;
+import com.example.dnd_13th_9_be.folder.application.dto.RecordSummaryResult;
 
 public interface FolderRepository {
   FolderDetailResult create(Long userId, Long planId, String name, boolean isDefault);

--- a/src/main/java/com/example/dnd_13th_9_be/folder/application/repository/FolderRepository.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/application/repository/FolderRepository.java
@@ -1,5 +1,6 @@
 package com.example.dnd_13th_9_be.folder.application.repository;
 
+import com.example.dnd_13th_9_be.folder.application.dto.RecordSummaryResult;
 import java.util.List;
 
 import com.example.dnd_13th_9_be.folder.application.dto.FolderDetailResult;
@@ -21,4 +22,6 @@ public interface FolderRepository {
   FolderDetailResult findByIdAndUserId(Long folderId, Long userId);
 
   long countFolderRecord(Long folderId);
+
+  List<RecordSummaryResult> findAllRecordByIdAndUserId(Long folderId, Long userId);
 }

--- a/src/main/java/com/example/dnd_13th_9_be/folder/persistence/FolderRepositoryImpl.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/persistence/FolderRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com.example.dnd_13th_9_be.folder.persistence;
 
+import com.example.dnd_13th_9_be.folder.application.dto.RecordSummaryResult;
+import com.example.dnd_13th_9_be.folder.persistence.dto.RecordSummary;
 import java.util.List;
 import jakarta.persistence.EntityManager;
 
@@ -89,5 +91,11 @@ public class FolderRepositoryImpl implements FolderRepository {
   @Override
   public long countFolderRecord(Long folderId) {
     return jpaFolderRepository.countFolderRecord(folderId);
+  }
+
+  @Override
+  public List<RecordSummaryResult> findAllRecordByIdAndUserId(Long userId, Long folderId) {
+    List<RecordSummary> records = jpaFolderRepository.findAllRecordByIdAndUserId(userId, folderId);
+    return records.stream().map(RecordSummaryResult::from).toList();
   }
 }

--- a/src/main/java/com/example/dnd_13th_9_be/folder/persistence/FolderRepositoryImpl.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/persistence/FolderRepositoryImpl.java
@@ -1,7 +1,5 @@
 package com.example.dnd_13th_9_be.folder.persistence;
 
-import com.example.dnd_13th_9_be.folder.application.dto.RecordSummaryResult;
-import com.example.dnd_13th_9_be.folder.persistence.dto.RecordSummary;
 import java.util.List;
 import jakarta.persistence.EntityManager;
 
@@ -11,7 +9,9 @@ import lombok.RequiredArgsConstructor;
 
 import com.example.dnd_13th_9_be.folder.application.dto.FolderDetailResult;
 import com.example.dnd_13th_9_be.folder.application.dto.FolderSummaryResult;
+import com.example.dnd_13th_9_be.folder.application.dto.RecordSummaryResult;
 import com.example.dnd_13th_9_be.folder.application.repository.FolderRepository;
+import com.example.dnd_13th_9_be.folder.persistence.dto.RecordSummary;
 import com.example.dnd_13th_9_be.folder.persistence.entity.Folder;
 import com.example.dnd_13th_9_be.global.error.BusinessException;
 import com.example.dnd_13th_9_be.plan.persistence.entity.Plan;

--- a/src/main/java/com/example/dnd_13th_9_be/folder/persistence/QueryDslFolderRepository.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/persistence/QueryDslFolderRepository.java
@@ -1,10 +1,9 @@
 package com.example.dnd_13th_9_be.folder.persistence;
 
-import com.example.dnd_13th_9_be.folder.application.dto.RecordSummaryResult;
-import com.example.dnd_13th_9_be.folder.persistence.dto.RecordSummary;
 import java.util.List;
 
 import com.example.dnd_13th_9_be.folder.persistence.dto.FolderSummary;
+import com.example.dnd_13th_9_be.folder.persistence.dto.RecordSummary;
 
 public interface QueryDslFolderRepository {
   List<FolderSummary> findSummariesByPlanId(Long userId, Long planId);

--- a/src/main/java/com/example/dnd_13th_9_be/folder/persistence/QueryDslFolderRepository.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/persistence/QueryDslFolderRepository.java
@@ -1,5 +1,7 @@
 package com.example.dnd_13th_9_be.folder.persistence;
 
+import com.example.dnd_13th_9_be.folder.application.dto.RecordSummaryResult;
+import com.example.dnd_13th_9_be.folder.persistence.dto.RecordSummary;
 import java.util.List;
 
 import com.example.dnd_13th_9_be.folder.persistence.dto.FolderSummary;
@@ -14,4 +16,6 @@ public interface QueryDslFolderRepository {
   Long countByPlanId(Long planId);
 
   Long countFolderRecord(Long folderId);
+
+  List<RecordSummary> findAllRecordByIdAndUserId(Long userId, Long folderId);
 }

--- a/src/main/java/com/example/dnd_13th_9_be/folder/persistence/QueryDslFolderRepositoryImpl.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/persistence/QueryDslFolderRepositoryImpl.java
@@ -1,24 +1,24 @@
 package com.example.dnd_13th_9_be.folder.persistence;
 
-import static com.querydsl.core.group.GroupBy.groupBy;
-import static com.querydsl.core.group.GroupBy.list;
-
-import com.example.dnd_13th_9_be.folder.persistence.dto.RecordSummary;
-import com.example.dnd_13th_9_be.folder.persistence.entity.RecordType;
-import com.example.dnd_13th_9_be.property.persistence.entity.QPropertyImage;
-import com.querydsl.core.types.dsl.Expressions;
 import java.util.List;
 import java.util.Optional;
 
 import lombok.RequiredArgsConstructor;
 
 import com.example.dnd_13th_9_be.folder.persistence.dto.FolderSummary;
+import com.example.dnd_13th_9_be.folder.persistence.dto.RecordSummary;
 import com.example.dnd_13th_9_be.folder.persistence.entity.QFolder;
+import com.example.dnd_13th_9_be.folder.persistence.entity.RecordType;
 import com.example.dnd_13th_9_be.location.persistence.QLocationRecordEntity;
 import com.example.dnd_13th_9_be.property.persistence.entity.QProperty;
+import com.example.dnd_13th_9_be.property.persistence.entity.QPropertyImage;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import static com.querydsl.core.group.GroupBy.groupBy;
+import static com.querydsl.core.group.GroupBy.list;
 
 @RequiredArgsConstructor
 public class QueryDslFolderRepositoryImpl implements QueryDslFolderRepository {
@@ -114,29 +114,36 @@ public class QueryDslFolderRepositoryImpl implements QueryDslFolderRepository {
 
     return query
         .from(property)
-        .leftJoin(propertyImage).on(propertyImage.property.eq(property))
+        .leftJoin(propertyImage)
+        .on(propertyImage.property.eq(property))
         .where(property.folder.id.eq(folderId))
-        .orderBy(property.createdAt.desc(), property.id.desc(), propertyImage.imageOrder.asc(), propertyImage.id.asc())
-        .transform(groupBy(property.id).list(
-            Projections.constructor(RecordSummary.class,
-                list(Projections.constructor(RecordSummary.RecordImageSummary.class,
-                    propertyImage.imageUrl,
-                    propertyImage.imageOrder
-                    )),
-                property.id,
-                Expressions.constant(RecordType.PROPERTY),
-                property.feeling,
-                property.title,
-                property.contractType,
-                property.depositBig,
-                property.depositSmall,
-                property.managementFee,
-                property.memo,
-                Expressions.nullExpression(String.class),
-                property.latitude,
-                property.longitude,
-                property.createdAt
-            )
-        ));
+        .orderBy(
+            property.createdAt.desc(),
+            property.id.desc(),
+            propertyImage.imageOrder.asc(),
+            propertyImage.id.asc())
+        .transform(
+            groupBy(property.id)
+                .list(
+                    Projections.constructor(
+                        RecordSummary.class,
+                        list(
+                            Projections.constructor(
+                                RecordSummary.RecordImageSummary.class,
+                                propertyImage.imageUrl,
+                                propertyImage.imageOrder)),
+                        property.id,
+                        Expressions.constant(RecordType.PROPERTY),
+                        property.feeling,
+                        property.title,
+                        property.contractType,
+                        property.depositBig,
+                        property.depositSmall,
+                        property.managementFee,
+                        property.memo,
+                        Expressions.nullExpression(String.class),
+                        property.latitude,
+                        property.longitude,
+                        property.createdAt)));
   }
 }

--- a/src/main/java/com/example/dnd_13th_9_be/folder/persistence/dto/RecordSummary.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/persistence/dto/RecordSummary.java
@@ -1,10 +1,11 @@
 package com.example.dnd_13th_9_be.folder.persistence.dto;
 
+import java.sql.Timestamp;
+import java.util.List;
+
 import com.example.dnd_13th_9_be.folder.persistence.entity.RecordType;
 import com.example.dnd_13th_9_be.property.persistence.entity.type.ContractType;
 import com.example.dnd_13th_9_be.property.persistence.entity.type.FeelingType;
-import java.sql.Timestamp;
-import java.util.List;
 
 public record RecordSummary(
     List<RecordImageSummary> images,
@@ -20,16 +21,7 @@ public record RecordSummary(
     String locationTag,
     Double latitude,
     Double longitude,
-    Timestamp createdAt
+    Timestamp createdAt) {
 
-    ) {
-
-    public record RecordImageSummary(
-        String url,
-        Integer order
-    ) {
-
-    }
-
+  public record RecordImageSummary(String url, Integer order) {}
 }
-

--- a/src/main/java/com/example/dnd_13th_9_be/folder/persistence/dto/RecordSummary.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/persistence/dto/RecordSummary.java
@@ -1,0 +1,35 @@
+package com.example.dnd_13th_9_be.folder.persistence.dto;
+
+import com.example.dnd_13th_9_be.folder.persistence.entity.RecordType;
+import com.example.dnd_13th_9_be.property.persistence.entity.type.ContractType;
+import com.example.dnd_13th_9_be.property.persistence.entity.type.FeelingType;
+import java.sql.Timestamp;
+import java.util.List;
+
+public record RecordSummary(
+    List<RecordImageSummary> images,
+    Long id,
+    RecordType recordType,
+    FeelingType feeling,
+    String title,
+    ContractType contractType,
+    Integer depositBig,
+    Integer depositSmall,
+    Integer managementFee,
+    String memo,
+    String locationTag,
+    Double latitude,
+    Double longitude,
+    Timestamp createdAt
+
+    ) {
+
+    public record RecordImageSummary(
+        String url,
+        Integer order
+    ) {
+
+    }
+
+}
+

--- a/src/main/java/com/example/dnd_13th_9_be/folder/persistence/entity/RecordType.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/persistence/entity/RecordType.java
@@ -6,8 +6,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum RecordType {
-    PROPERTY("매물 메모"),
-    LOCATION("장소 메모");
+  PROPERTY("매물 메모"),
+  LOCATION("장소 메모");
 
-    private final String name;
+  private final String name;
 }

--- a/src/main/java/com/example/dnd_13th_9_be/folder/persistence/entity/RecordType.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/persistence/entity/RecordType.java
@@ -1,0 +1,13 @@
+package com.example.dnd_13th_9_be.folder.persistence.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum RecordType {
+    PROPERTY("매물 메모"),
+    LOCATION("장소 메모");
+
+    private final String name;
+}

--- a/src/main/java/com/example/dnd_13th_9_be/folder/presentation/FolderController.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/presentation/FolderController.java
@@ -1,5 +1,6 @@
 package com.example.dnd_13th_9_be.folder.presentation;
 
+import com.example.dnd_13th_9_be.folder.presentation.dto.response.RecordSummaryResponse;
 import java.util.List;
 import java.util.Map;
 import jakarta.validation.Valid;
@@ -69,5 +70,16 @@ public class FolderController implements FolderDocs {
       @PathVariable("folderId") Long folderId) {
     folderService.deleteFolder(userDetails.getUserId(), folderId);
     return ApiResponse.okEntity();
+  }
+
+  @Override
+  @GetMapping("/{folderId}/records")
+  public ResponseEntity<ApiResponse<List<RecordSummaryResponse>>> getRecordList(
+      @AuthenticationPrincipal UserPrincipalDto userDetails,
+      @PathVariable("folderId") Long folderId
+  ) {
+    List<RecordSummaryResponse> result = folderService.getRecordList(userDetails.getUserId(), folderId)
+        .stream().map(RecordSummaryResponse::from).toList();
+    return ApiResponse.successEntity(result);
   }
 }

--- a/src/main/java/com/example/dnd_13th_9_be/folder/presentation/FolderController.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/presentation/FolderController.java
@@ -1,6 +1,5 @@
 package com.example.dnd_13th_9_be.folder.presentation;
 
-import com.example.dnd_13th_9_be.folder.presentation.dto.response.RecordSummaryResponse;
 import java.util.List;
 import java.util.Map;
 import jakarta.validation.Valid;
@@ -24,6 +23,7 @@ import com.example.dnd_13th_9_be.folder.presentation.dto.request.CreateFolderReq
 import com.example.dnd_13th_9_be.folder.presentation.dto.request.RenameFolderRequest;
 import com.example.dnd_13th_9_be.folder.presentation.dto.response.FolderDetailResponse;
 import com.example.dnd_13th_9_be.folder.presentation.dto.response.FolderSummaryResponse;
+import com.example.dnd_13th_9_be.folder.presentation.dto.response.RecordSummaryResponse;
 import com.example.dnd_13th_9_be.global.response.ApiResponse;
 import com.example.dnd_13th_9_be.user.application.dto.UserPrincipalDto;
 
@@ -76,10 +76,11 @@ public class FolderController implements FolderDocs {
   @GetMapping("/{folderId}/records")
   public ResponseEntity<ApiResponse<List<RecordSummaryResponse>>> getRecordList(
       @AuthenticationPrincipal UserPrincipalDto userDetails,
-      @PathVariable("folderId") Long folderId
-  ) {
-    List<RecordSummaryResponse> result = folderService.getRecordList(userDetails.getUserId(), folderId)
-        .stream().map(RecordSummaryResponse::from).toList();
+      @PathVariable("folderId") Long folderId) {
+    List<RecordSummaryResponse> result =
+        folderService.getRecordList(userDetails.getUserId(), folderId).stream()
+            .map(RecordSummaryResponse::from)
+            .toList();
     return ApiResponse.successEntity(result);
   }
 }

--- a/src/main/java/com/example/dnd_13th_9_be/folder/presentation/docs/FolderDocs.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/presentation/docs/FolderDocs.java
@@ -1,6 +1,5 @@
 package com.example.dnd_13th_9_be.folder.presentation.docs;
 
-import com.example.dnd_13th_9_be.folder.presentation.dto.response.RecordSummaryResponse;
 import java.util.List;
 import java.util.Map;
 import jakarta.validation.Valid;
@@ -18,6 +17,7 @@ import com.example.dnd_13th_9_be.folder.presentation.dto.request.CreateFolderReq
 import com.example.dnd_13th_9_be.folder.presentation.dto.request.RenameFolderRequest;
 import com.example.dnd_13th_9_be.folder.presentation.dto.response.FolderDetailResponse;
 import com.example.dnd_13th_9_be.folder.presentation.dto.response.FolderSummaryResponse;
+import com.example.dnd_13th_9_be.folder.presentation.dto.response.RecordSummaryResponse;
 import com.example.dnd_13th_9_be.global.response.ApiResponse;
 import com.example.dnd_13th_9_be.user.application.dto.UserPrincipalDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -350,20 +350,20 @@ public interface FolderDocs {
           @PathVariable("folderId")
           Long folderId);
 
-    @Operation(summary = "폴더 내 기록 조회", description = "지정된 폴더에 포함된 매물/장소 메모 기록 목록을 조회한다.")
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200",
-            description = "성공",
-            content =
+  @Operation(summary = "폴더 내 기록 조회", description = "지정된 폴더에 포함된 매물/장소 메모 기록 목록을 조회한다.")
+  @ApiResponses({
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "200",
+        description = "성공",
+        content =
             @Content(
                 mediaType = "application/json",
                 schema = @Schema(implementation = ApiResponse.class),
                 examples =
-                @ExampleObject(
-                    name = "성공 예시",
-                    value =
-                        """
+                    @ExampleObject(
+                        name = "성공 예시",
+                        value =
+                            """
               {
                 "code": "20000",
                 "message": "성공했습니다",
@@ -403,28 +403,29 @@ public interface FolderDocs {
                 ]
               }
               """))),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "404",
-            description = "유효하지 않은 폴더 id",
-            content =
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "404",
+        description = "유효하지 않은 폴더 id",
+        content =
             @Content(
                 mediaType = "application/json",
                 schema = @Schema(implementation = ApiResponse.class),
                 examples =
-                @ExampleObject(
-                    name = "폴더 없음 예시",
-                    value =
-                        """
+                    @ExampleObject(
+                        name = "폴더 없음 예시",
+                        value =
+                            """
               {
                 "code": "72000",
                 "message": "유효하지 않은 폴더입니다",
                 "data": null
               }
               """)))
-    })
-    @GetMapping("/{folderId}/records")
-    ResponseEntity<ApiResponse<List<RecordSummaryResponse>>> getRecordList(
-        @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipalDto userDetails,
-        @Parameter(description = "폴더 고유 인덱스 값", example = "12", required = true) @PathVariable("folderId") Long folderId
-    );
+  })
+  @GetMapping("/{folderId}/records")
+  ResponseEntity<ApiResponse<List<RecordSummaryResponse>>> getRecordList(
+      @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipalDto userDetails,
+      @Parameter(description = "폴더 고유 인덱스 값", example = "12", required = true)
+          @PathVariable("folderId")
+          Long folderId);
 }

--- a/src/main/java/com/example/dnd_13th_9_be/folder/presentation/docs/FolderDocs.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/presentation/docs/FolderDocs.java
@@ -1,5 +1,6 @@
 package com.example.dnd_13th_9_be.folder.presentation.docs;
 
+import com.example.dnd_13th_9_be.folder.presentation.dto.response.RecordSummaryResponse;
 import java.util.List;
 import java.util.Map;
 import jakarta.validation.Valid;
@@ -348,4 +349,82 @@ public interface FolderDocs {
       @Parameter(description = "폴더 고유 인덱스 값", example = "12", required = true)
           @PathVariable("folderId")
           Long folderId);
+
+    @Operation(summary = "폴더 내 기록 조회", description = "지정된 폴더에 포함된 매물/장소 메모 기록 목록을 조회한다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "성공",
+            content =
+            @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ApiResponse.class),
+                examples =
+                @ExampleObject(
+                    name = "성공 예시",
+                    value =
+                        """
+              {
+                "code": "20000",
+                "message": "성공했습니다",
+                "data": [
+                  {
+                    "id": 35,
+                    "imageUrl": "https://zipzip-bucket.s3.amazonaws.com/images/58be7686-3fcb-4655-b3aa-fe9e713c0ab7.jpeg",
+                    "recordType": "PROPERTY",
+                    "feeling": "BAD",
+                    "title": "안 괜찮은 원룸",
+                    "contractType": "JEONSE",
+                    "depositBig": 1,
+                    "depositSmall": 2,
+                    "managementFee": null,
+                    "memo": "이 집은 될 수 있으면 피할 것!",
+                    "locationTag": null,
+                    "latitude": 35.098237529977,
+                    "longitude": 128.981411608042,
+                    "createdAt": "2025-08-25T00:11:17.844533"
+                  },
+                  {
+                    "id": 34,
+                    "imageUrl": null,
+                    "recordType": "PROPERTY",
+                    "feeling": "GOOD",
+                    "title": "괜찮은 원룸",
+                    "contractType": "MONTHLY_RENT",
+                    "depositBig": 7,
+                    "depositSmall": 10,
+                    "managementFee": 10,
+                    "memo": "제일 우선 순위",
+                    "locationTag": null,
+                    "latitude": 35.098237529973,
+                    "longitude": 128.981411608041,
+                    "createdAt": "2025-08-24T23:51:03.065649"
+                  }
+                ]
+              }
+              """))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404",
+            description = "유효하지 않은 폴더 id",
+            content =
+            @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ApiResponse.class),
+                examples =
+                @ExampleObject(
+                    name = "폴더 없음 예시",
+                    value =
+                        """
+              {
+                "code": "72000",
+                "message": "유효하지 않은 폴더입니다",
+                "data": null
+              }
+              """)))
+    })
+    @GetMapping("/{folderId}/records")
+    ResponseEntity<ApiResponse<List<RecordSummaryResponse>>> getRecordList(
+        @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipalDto userDetails,
+        @Parameter(description = "폴더 고유 인덱스 값", example = "12", required = true) @PathVariable("folderId") Long folderId
+    );
 }

--- a/src/main/java/com/example/dnd_13th_9_be/folder/presentation/dto/response/RecordSummaryResponse.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/presentation/dto/response/RecordSummaryResponse.java
@@ -1,0 +1,42 @@
+package com.example.dnd_13th_9_be.folder.presentation.dto.response;
+
+import com.example.dnd_13th_9_be.folder.application.dto.RecordSummaryResult;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record RecordSummaryResponse(
+    Long id,
+    String imageUrl,
+    String recordType,
+    String feeling,
+    String title,
+    String contractType,
+    Integer depositBig,
+    Integer depositSmall,
+    Integer managementFee,
+    String memo,
+    String locationTag,
+    Double latitude,
+    Double longitude,
+    LocalDateTime createdAt
+) {
+    public static RecordSummaryResponse from(RecordSummaryResult result) {
+        return RecordSummaryResponse.builder()
+            .id(result.id())
+            .imageUrl(result.imageUrl())
+            .recordType(result.recordType())
+            .feeling(result.feeling())
+            .title(result.title())
+            .contractType(result.contractType())
+            .depositBig(result.depositBig())
+            .depositSmall(result.depositSmall())
+            .managementFee(result.managementFee())
+            .memo(result.memo())
+            .locationTag(result.locationTag())
+            .latitude(result.latitude())
+            .longitude(result.longitude())
+            .createdAt(result.createdAt())
+            .build();
+    }
+}

--- a/src/main/java/com/example/dnd_13th_9_be/folder/presentation/dto/response/RecordSummaryResponse.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/presentation/dto/response/RecordSummaryResponse.java
@@ -1,8 +1,10 @@
 package com.example.dnd_13th_9_be.folder.presentation.dto.response;
 
-import com.example.dnd_13th_9_be.folder.application.dto.RecordSummaryResult;
 import java.time.LocalDateTime;
+
 import lombok.Builder;
+
+import com.example.dnd_13th_9_be.folder.application.dto.RecordSummaryResult;
 
 @Builder
 public record RecordSummaryResponse(
@@ -19,24 +21,23 @@ public record RecordSummaryResponse(
     String locationTag,
     Double latitude,
     Double longitude,
-    LocalDateTime createdAt
-) {
-    public static RecordSummaryResponse from(RecordSummaryResult result) {
-        return RecordSummaryResponse.builder()
-            .id(result.id())
-            .imageUrl(result.imageUrl())
-            .recordType(result.recordType())
-            .feeling(result.feeling())
-            .title(result.title())
-            .contractType(result.contractType())
-            .depositBig(result.depositBig())
-            .depositSmall(result.depositSmall())
-            .managementFee(result.managementFee())
-            .memo(result.memo())
-            .locationTag(result.locationTag())
-            .latitude(result.latitude())
-            .longitude(result.longitude())
-            .createdAt(result.createdAt())
-            .build();
-    }
+    LocalDateTime createdAt) {
+  public static RecordSummaryResponse from(RecordSummaryResult result) {
+    return RecordSummaryResponse.builder()
+        .id(result.id())
+        .imageUrl(result.imageUrl())
+        .recordType(result.recordType())
+        .feeling(result.feeling())
+        .title(result.title())
+        .contractType(result.contractType())
+        .depositBig(result.depositBig())
+        .depositSmall(result.depositSmall())
+        .managementFee(result.managementFee())
+        .memo(result.memo())
+        .locationTag(result.locationTag())
+        .latitude(result.latitude())
+        .longitude(result.longitude())
+        .createdAt(result.createdAt())
+        .build();
+  }
 }


### PR DESCRIPTION
# Changes 📝
closes #51 
- 폴더에 저장된 매물 메모 전체를 조회하여 리스트 형태로 반환하는 API를 추가했습니다.

# to 리뷰어
- 추후 장소 메모 Entity 참고해서 수정해 놓겠습니다.

# Screenshot 📷