### PR TITLE
[feat] 최근 본 매물 API

### DIFF
--- a/src/main/java/com/example/dnd_13th_9_be/property/application/PropertyService.java
+++ b/src/main/java/com/example/dnd_13th_9_be/property/application/PropertyService.java
@@ -236,8 +236,8 @@ public class PropertyService {
             });
   }
 
-  public List<RecentPropertyModel> findTopByUserId(Long userId) {
-    return propertyRepository.findTopByUserId(userId).stream()
+  public List<RecentPropertyModel> findTopByUserId(Long userId, int size) {
+    return propertyRepository.findTopByUserId(userId, size).stream()
         .map(RecentPropertyModel::from)
         .toList();
   }

--- a/src/main/java/com/example/dnd_13th_9_be/property/application/PropertyService.java
+++ b/src/main/java/com/example/dnd_13th_9_be/property/application/PropertyService.java
@@ -27,6 +27,7 @@ import com.example.dnd_13th_9_be.global.error.S3ImageException;
 import com.example.dnd_13th_9_be.property.application.model.PropertyCategoryMemoModel;
 import com.example.dnd_13th_9_be.property.application.model.PropertyImageModel;
 import com.example.dnd_13th_9_be.property.application.model.PropertyModel;
+import com.example.dnd_13th_9_be.property.application.model.RecentPropertyModel;
 import com.example.dnd_13th_9_be.property.application.repository.PropertyCategoryMemoRepository;
 import com.example.dnd_13th_9_be.property.application.repository.PropertyImageRepository;
 import com.example.dnd_13th_9_be.property.application.repository.PropertyRepository;
@@ -233,5 +234,11 @@ public class PropertyService {
                     categoryId, propertyId);
               }
             });
+  }
+
+  public List<RecentPropertyModel> findTopByUserId(Long userId) {
+    return propertyRepository.findTopByUserId(userId).stream()
+        .map(RecentPropertyModel::from)
+        .toList();
   }
 }

--- a/src/main/java/com/example/dnd_13th_9_be/property/application/model/RecentPropertyModel.java
+++ b/src/main/java/com/example/dnd_13th_9_be/property/application/model/RecentPropertyModel.java
@@ -1,0 +1,33 @@
+package com.example.dnd_13th_9_be.property.application.model;
+
+import lombok.Builder;
+
+import com.example.dnd_13th_9_be.property.persistence.dto.RecentPropertyResult;
+
+@Builder
+public record RecentPropertyModel(
+    Long propertyId,
+    String imageUrl,
+    String feeling,
+    String title,
+    Integer depositBig,
+    Integer depositSmall,
+    Integer managementFee,
+    String contractType,
+    String planName,
+    String folderName) {
+  public static RecentPropertyModel from(RecentPropertyResult result) {
+    return RecentPropertyModel.builder()
+        .propertyId(result.propertyId())
+        .imageUrl(result.imageUrl())
+        .feeling(result.feeling() == null ? null : result.feeling().name())
+        .title(result.title())
+        .depositBig(result.depositBig())
+        .depositSmall(result.depositSmall())
+        .managementFee(result.managementFee())
+        .contractType(result.contractType() == null ? null : result.contractType().name())
+        .planName(result.planName())
+        .folderName(result.folderName())
+        .build();
+  }
+}

--- a/src/main/java/com/example/dnd_13th_9_be/property/application/repository/PropertyRepository.java
+++ b/src/main/java/com/example/dnd_13th_9_be/property/application/repository/PropertyRepository.java
@@ -1,7 +1,10 @@
 package com.example.dnd_13th_9_be.property.application.repository;
 
+import java.util.List;
+
 import com.example.dnd_13th_9_be.property.application.model.PropertyModel;
 import com.example.dnd_13th_9_be.property.persistence.dto.PropertyResult;
+import com.example.dnd_13th_9_be.property.persistence.dto.RecentPropertyResult;
 
 public interface PropertyRepository {
   void verifyExistsById(Long userId, Long propertyId);
@@ -13,4 +16,6 @@ public interface PropertyRepository {
   PropertyResult save(PropertyModel dto);
 
   void update(Long userId, Long propertyId, PropertyModel dto);
+
+  List<RecentPropertyResult> findTopByUserId(Long userId);
 }

--- a/src/main/java/com/example/dnd_13th_9_be/property/application/repository/PropertyRepository.java
+++ b/src/main/java/com/example/dnd_13th_9_be/property/application/repository/PropertyRepository.java
@@ -17,5 +17,5 @@ public interface PropertyRepository {
 
   void update(Long userId, Long propertyId, PropertyModel dto);
 
-  List<RecentPropertyResult> findTopByUserId(Long userId);
+  List<RecentPropertyResult> findTopByUserId(Long userId, int size);
 }

--- a/src/main/java/com/example/dnd_13th_9_be/property/persistence/PropertyRepositoryImpl.java
+++ b/src/main/java/com/example/dnd_13th_9_be/property/persistence/PropertyRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.example.dnd_13th_9_be.property.persistence;
 
+import java.util.List;
 import jakarta.persistence.EntityManager;
 
 import org.springframework.stereotype.Component;
@@ -7,12 +8,17 @@ import org.springframework.stereotype.Component;
 import lombok.RequiredArgsConstructor;
 
 import com.example.dnd_13th_9_be.folder.persistence.entity.Folder;
+import com.example.dnd_13th_9_be.folder.persistence.entity.QFolder;
 import com.example.dnd_13th_9_be.global.error.BusinessException;
+import com.example.dnd_13th_9_be.plan.persistence.entity.QPlan;
 import com.example.dnd_13th_9_be.property.application.model.PropertyModel;
 import com.example.dnd_13th_9_be.property.application.repository.PropertyRepository;
 import com.example.dnd_13th_9_be.property.persistence.dto.PropertyResult;
+import com.example.dnd_13th_9_be.property.persistence.dto.RecentPropertyResult;
 import com.example.dnd_13th_9_be.property.persistence.entity.Property;
 import com.example.dnd_13th_9_be.property.persistence.entity.QProperty;
+import com.example.dnd_13th_9_be.property.persistence.entity.QPropertyImage;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import static com.example.dnd_13th_9_be.global.error.ErrorCode.NOT_FOUND_PROPERTY;
@@ -100,5 +106,36 @@ public class PropertyRepositoryImpl implements PropertyRepository {
     }
     savedProperty.update(dto);
     jpaPropertyRepository.save(savedProperty);
+  }
+
+  public List<RecentPropertyResult> findTopByUserId(Long userId) {
+    var property = QProperty.property;
+    var propertyImage = QPropertyImage.propertyImage;
+    var plan = QPlan.plan;
+    var folder = QFolder.folder;
+
+    return query
+        .from(property)
+        .join(property.folder, folder)
+        .leftJoin(folder.plan, plan)
+        .leftJoin(propertyImage)
+        .on(propertyImage.property.eq(property).and(propertyImage.imageOrder.eq(1)))
+        .where(folder.user.id.eq(userId))
+        .orderBy(property.createdAt.desc(), property.id.desc())
+        .limit(10)
+        .select(
+            Projections.constructor(
+                RecentPropertyResult.class,
+                property.id,
+                propertyImage.imageUrl,
+                property.feeling,
+                property.title,
+                property.depositBig,
+                property.depositSmall,
+                property.managementFee,
+                property.contractType,
+                plan.name,
+                folder.name))
+        .fetch();
   }
 }

--- a/src/main/java/com/example/dnd_13th_9_be/property/persistence/PropertyRepositoryImpl.java
+++ b/src/main/java/com/example/dnd_13th_9_be/property/persistence/PropertyRepositoryImpl.java
@@ -108,7 +108,7 @@ public class PropertyRepositoryImpl implements PropertyRepository {
     jpaPropertyRepository.save(savedProperty);
   }
 
-  public List<RecentPropertyResult> findTopByUserId(Long userId) {
+  public List<RecentPropertyResult> findTopByUserId(Long userId, int size) {
     var property = QProperty.property;
     var propertyImage = QPropertyImage.propertyImage;
     var plan = QPlan.plan;
@@ -122,7 +122,7 @@ public class PropertyRepositoryImpl implements PropertyRepository {
         .on(propertyImage.property.eq(property).and(propertyImage.imageOrder.eq(1)))
         .where(folder.user.id.eq(userId))
         .orderBy(property.createdAt.desc(), property.id.desc())
-        .limit(10)
+        .limit(size)
         .select(
             Projections.constructor(
                 RecentPropertyResult.class,

--- a/src/main/java/com/example/dnd_13th_9_be/property/persistence/dto/RecentPropertyResult.java
+++ b/src/main/java/com/example/dnd_13th_9_be/property/persistence/dto/RecentPropertyResult.java
@@ -1,0 +1,16 @@
+package com.example.dnd_13th_9_be.property.persistence.dto;
+
+import com.example.dnd_13th_9_be.property.persistence.entity.type.ContractType;
+import com.example.dnd_13th_9_be.property.persistence.entity.type.FeelingType;
+
+public record RecentPropertyResult(
+    Long propertyId,
+    String imageUrl,
+    FeelingType feeling,
+    String title,
+    Integer depositBig,
+    Integer depositSmall,
+    Integer managementFee,
+    ContractType contractType,
+    String planName,
+    String folderName) {}

--- a/src/main/java/com/example/dnd_13th_9_be/property/persistence/entity/PropertyImage.java
+++ b/src/main/java/com/example/dnd_13th_9_be/property/persistence/entity/PropertyImage.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -20,7 +21,12 @@ import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
-@Table(name = "property_image")
+@Table(
+    name = "property_image",
+    uniqueConstraints =
+        @UniqueConstraint(
+            name = "uk_property_image_order",
+            columnNames = {"property_id", "image_order"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PropertyImage extends BaseEntity {

--- a/src/main/java/com/example/dnd_13th_9_be/property/presentation/PropertyController.java
+++ b/src/main/java/com/example/dnd_13th_9_be/property/presentation/PropertyController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -74,10 +75,13 @@ public class PropertyController implements PropertyDocs {
     return ApiResponse.okEntity();
   }
 
+  @Override
   @GetMapping("/recent")
   public ResponseEntity<ApiResponse<List<RecentPropertyModel>>> getRecentProperties(
-      @AuthenticationPrincipal UserPrincipalDto userDetails) {
-    List<RecentPropertyModel> result = propertyService.findTopByUserId(userDetails.getUserId());
+      @AuthenticationPrincipal UserPrincipalDto userDetails,
+      @RequestParam(name = "size", defaultValue = "10") int size) {
+    List<RecentPropertyModel> result =
+        propertyService.findTopByUserId(userDetails.getUserId(), size);
     return ApiResponse.successEntity(result);
   }
 }

--- a/src/main/java/com/example/dnd_13th_9_be/property/presentation/PropertyController.java
+++ b/src/main/java/com/example/dnd_13th_9_be/property/presentation/PropertyController.java
@@ -20,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 
 import com.example.dnd_13th_9_be.global.response.ApiResponse;
 import com.example.dnd_13th_9_be.property.application.PropertyService;
+import com.example.dnd_13th_9_be.property.application.model.RecentPropertyModel;
 import com.example.dnd_13th_9_be.property.presentation.docs.PropertyDocs;
 import com.example.dnd_13th_9_be.property.presentation.dto.request.UpsertPropertyRequest;
 import com.example.dnd_13th_9_be.property.presentation.dto.response.PropertyDetailResponse;
@@ -71,5 +72,12 @@ public class PropertyController implements PropertyDocs {
     propertyService.updateProperty(userDetails.getUserId(), propertyId, files, request);
 
     return ApiResponse.okEntity();
+  }
+
+  @GetMapping("/recent")
+  public ResponseEntity<ApiResponse<List<RecentPropertyModel>>> getRecentProperties(
+      @AuthenticationPrincipal UserPrincipalDto userDetails) {
+    List<RecentPropertyModel> result = propertyService.findTopByUserId(userDetails.getUserId());
+    return ApiResponse.successEntity(result);
   }
 }

--- a/src/main/java/com/example/dnd_13th_9_be/property/presentation/docs/PropertyDocs.java
+++ b/src/main/java/com/example/dnd_13th_9_be/property/presentation/docs/PropertyDocs.java
@@ -11,10 +11,12 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.example.dnd_13th_9_be.global.response.ApiResponse;
+import com.example.dnd_13th_9_be.property.application.model.RecentPropertyModel;
 import com.example.dnd_13th_9_be.property.presentation.dto.request.UpsertPropertyRequest;
 import com.example.dnd_13th_9_be.property.presentation.dto.response.PropertyDetailResponse;
 import com.example.dnd_13th_9_be.user.application.dto.UserPrincipalDto;
@@ -25,6 +27,7 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "매물", description = "매물(Property) 관련 API")
@@ -463,4 +466,83 @@ public interface PropertyDocs {
           Long propertyId,
       @RequestPart(value = "image", required = false) List<MultipartFile> files,
       @Validated @RequestPart(value = "data") UpsertPropertyRequest request);
+
+  @Operation(
+      summary = "최근 매물 조회",
+      description =
+          """
+            사용자가 최근에 등록한 매물들을 최신 순으로 조회한다.
+            - 응답 데이터는 `size` 개수만큼 반환된다 (기본값 10).
+            - 매물에 첨부된 이미지 중 첫 번째(`order=1`) 이미지를 `imageUrl`에 담아 제공한다.
+            - 이미지가 없는 경우 `imageUrl`은 `null`일 수 있다.
+            """)
+  @ApiResponses({
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "200",
+        description = "성공",
+        content =
+            @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ApiResponse.class),
+                examples =
+                    @ExampleObject(
+                        name = "성공 예시",
+                        value =
+                            """
+                        {
+                          "code": "20000",
+                          "message": "성공했습니다",
+                          "data": [
+                            {
+                              "propertyId": 47,
+                              "imageUrl": null,
+                              "feeling": "BAD",
+                              "title": "11번째 집!",
+                              "depositBig": 0,
+                              "depositSmall": 1,
+                              "managementFee": null,
+                              "contractType": "JEONSE",
+                              "planName": "기본 계획",
+                              "folderName": "관악산근처"
+                            },
+                            {
+                              "propertyId": 42,
+                              "imageUrl": "https://zipzip-bucket.s3.amazonaws.com/images/c07f1844-d1c6-414d-bd60-78c21d79ec6e.jpeg",
+                              "feeling": "SOSO",
+                              "title": "관악산",
+                              "depositBig": 100,
+                              "depositSmall": 10,
+                              "managementFee": null,
+                              "contractType": "JEONSE",
+                              "planName": "기본 계획",
+                              "folderName": "관악산근처"
+                            }
+                          ]
+                        }
+                        """))),
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "401",
+        description = "인증 실패 (로그인 필요)",
+        content =
+            @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ApiResponse.class),
+                examples =
+                    @ExampleObject(
+                        name = "인증 실패 예시",
+                        value =
+                            """
+                        {
+                          "code": "40100",
+                          "message": "인증이 필요합니다",
+                          "data": null
+                        }
+                        """)))
+  })
+  @GetMapping("/recent")
+  ResponseEntity<ApiResponse<List<RecentPropertyModel>>> getRecentProperties(
+      @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipalDto userDetails,
+      @Parameter(name = "size", description = "응답 받을 매물 메모 갯수 (기본값 10, 옵션)", example = "5")
+          @RequestParam(name = "size", defaultValue = "10")
+          int size);
 }


### PR DESCRIPTION
# Changes 📝
closes #59 
- 홈 화면에서 최근에 작성한 매물 메모를 최대 10개 볼 수 있는 api를 추가했습니다

# Screenshot 📷
<img width="540" height="248" alt="스크린샷 2025-08-26 오후 10 01 03" src="https://github.com/user-attachments/assets/785d0fa9-e813-4625-9fbd-7fd422e5f291" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added GET /api/property/recent to fetch an authenticated user’s most recent properties. Supports size query (default 10). Returns property ID, image, title, deposit/management fees, contract type, feeling, plan name, and folder name. Results are ordered by latest activity.

- Documentation
  - Updated API docs to include the Recent Properties endpoint, parameters, authentication requirements, response schema, and sample responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->