### PR TITLE
[feat] 마이페이지 UI 구성 API

### DIFF
--- a/src/main/java/com/example/dnd_13th_9_be/checklist/application/repository/UserRequiredItemRepository.java
+++ b/src/main/java/com/example/dnd_13th_9_be/checklist/application/repository/UserRequiredItemRepository.java
@@ -12,4 +12,6 @@ public interface UserRequiredItemRepository {
   long delete(Long userId, Long itemId);
 
   List<UserRequiredItemModel> findAllByUserId(Long userId);
+
+  long countByUserId(Long userId);
 }

--- a/src/main/java/com/example/dnd_13th_9_be/checklist/persistence/UserRequiredItemRepositoryImpl.java
+++ b/src/main/java/com/example/dnd_13th_9_be/checklist/persistence/UserRequiredItemRepositoryImpl.java
@@ -12,9 +12,11 @@ import com.example.dnd_13th_9_be.checklist.application.model.UserRequiredItemMod
 import com.example.dnd_13th_9_be.checklist.application.model.converter.UserRequiredItemConverter;
 import com.example.dnd_13th_9_be.checklist.application.repository.UserRequiredItemRepository;
 import com.example.dnd_13th_9_be.checklist.persistence.entity.ChecklistItem;
+import com.example.dnd_13th_9_be.checklist.persistence.entity.QUserRequiredItem;
 import com.example.dnd_13th_9_be.checklist.persistence.entity.UserRequiredItem;
 import com.example.dnd_13th_9_be.checklist.persistence.repository.JpaUserRequiredItemRepository;
 import com.example.dnd_13th_9_be.user.persistence.User;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 
 @Repository
 @RequiredArgsConstructor
@@ -22,6 +24,7 @@ import com.example.dnd_13th_9_be.user.persistence.User;
 public class UserRequiredItemRepositoryImpl implements UserRequiredItemRepository {
   private final JpaUserRequiredItemRepository jpaUserRequiredItemRepository;
   private final UserRequiredItemConverter userRequiredItemConverter;
+  private final JPAQueryFactory query;
   private final EntityManager em;
 
   @Override
@@ -53,5 +56,17 @@ public class UserRequiredItemRepositoryImpl implements UserRequiredItemRepositor
     List<UserRequiredItem> requiredItems =
         jpaUserRequiredItemRepository.findAllByUserIdOrderByIdAsc(userId);
     return requiredItems.stream().map(userRequiredItemConverter::from).toList();
+  }
+
+  @Override
+  public long countByUserId(Long userId) {
+    var userRequiredItem = QUserRequiredItem.userRequiredItem;
+    Long count =
+        query
+            .select(userRequiredItem.count())
+            .from(userRequiredItem)
+            .where(userRequiredItem.user.id.eq(userId))
+            .fetchOne();
+    return count == null ? 0 : count;
   }
 }

--- a/src/main/java/com/example/dnd_13th_9_be/property/application/repository/PropertyRepository.java
+++ b/src/main/java/com/example/dnd_13th_9_be/property/application/repository/PropertyRepository.java
@@ -18,4 +18,6 @@ public interface PropertyRepository {
   void update(Long userId, Long propertyId, PropertyModel dto);
 
   List<RecentPropertyResult> findTopByUserId(Long userId, int size);
+
+  long countByUserId(Long userId);
 }

--- a/src/main/java/com/example/dnd_13th_9_be/property/persistence/PropertyRepositoryImpl.java
+++ b/src/main/java/com/example/dnd_13th_9_be/property/persistence/PropertyRepositoryImpl.java
@@ -138,4 +138,16 @@ public class PropertyRepositoryImpl implements PropertyRepository {
                 folder.name))
         .fetch();
   }
+
+  @Override
+  public long countByUserId(Long userId) {
+    var property = QProperty.property;
+    Long count =
+        query
+            .select(property.count())
+            .from(property)
+            .where(property.folder.user.id.eq(userId))
+            .fetchOne();
+    return count == null ? 0 : count;
+  }
 }

--- a/src/main/java/com/example/dnd_13th_9_be/user/application/dto/MyPageDto.java
+++ b/src/main/java/com/example/dnd_13th_9_be/user/application/dto/MyPageDto.java
@@ -1,0 +1,6 @@
+package com.example.dnd_13th_9_be.user.application.dto;
+
+import lombok.Builder;
+
+@Builder
+public record MyPageDto(String name, long propertyCount, long checklistCount) {}

--- a/src/main/java/com/example/dnd_13th_9_be/user/application/service/MyPageService.java
+++ b/src/main/java/com/example/dnd_13th_9_be/user/application/service/MyPageService.java
@@ -1,0 +1,38 @@
+package com.example.dnd_13th_9_be.user.application.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+import com.example.dnd_13th_9_be.checklist.application.repository.UserRequiredItemRepository;
+import com.example.dnd_13th_9_be.global.error.BusinessException;
+import com.example.dnd_13th_9_be.property.application.repository.PropertyRepository;
+import com.example.dnd_13th_9_be.user.application.dto.MyPageDto;
+import com.example.dnd_13th_9_be.user.application.repository.UserRepository;
+
+import static com.example.dnd_13th_9_be.global.error.ErrorCode.USER_NOT_FOUND;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MyPageService {
+  private final UserRepository userRepository;
+  private final PropertyRepository propertyRepository;
+  private final UserRequiredItemRepository userRequiredItemRepository;
+
+  public MyPageDto findUserInfo(Long userId) {
+    String userName =
+        userRepository
+            .findById(userId)
+            .orElseThrow(() -> new BusinessException(USER_NOT_FOUND))
+            .getName();
+    long propertyCount = propertyRepository.countByUserId(userId);
+    long checklistCount = userRequiredItemRepository.countByUserId(userId);
+    return MyPageDto.builder()
+        .name(userName)
+        .propertyCount(propertyCount)
+        .checklistCount(checklistCount)
+        .build();
+  }
+}

--- a/src/main/java/com/example/dnd_13th_9_be/user/presentation/MyPageController.java
+++ b/src/main/java/com/example/dnd_13th_9_be/user/presentation/MyPageController.java
@@ -1,0 +1,27 @@
+package com.example.dnd_13th_9_be.user.presentation;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+import com.example.dnd_13th_9_be.global.response.ApiResponse;
+import com.example.dnd_13th_9_be.user.application.dto.MyPageDto;
+import com.example.dnd_13th_9_be.user.application.dto.UserPrincipalDto;
+import com.example.dnd_13th_9_be.user.application.service.MyPageService;
+
+@RestController
+@RequestMapping("/api/mypage")
+@RequiredArgsConstructor
+public class MyPageController {
+  private final MyPageService myPageService;
+
+  @GetMapping
+  public ResponseEntity<ApiResponse<MyPageDto>> getUserInfo(
+      @AuthenticationPrincipal UserPrincipalDto userDetails) {
+    return ApiResponse.successEntity(myPageService.findUserInfo(userDetails.getUserId()));
+  }
+}

--- a/src/main/java/com/example/dnd_13th_9_be/user/presentation/MyPageController.java
+++ b/src/main/java/com/example/dnd_13th_9_be/user/presentation/MyPageController.java
@@ -12,13 +12,15 @@ import com.example.dnd_13th_9_be.global.response.ApiResponse;
 import com.example.dnd_13th_9_be.user.application.dto.MyPageDto;
 import com.example.dnd_13th_9_be.user.application.dto.UserPrincipalDto;
 import com.example.dnd_13th_9_be.user.application.service.MyPageService;
+import com.example.dnd_13th_9_be.user.presentation.docs.MyPageDocs;
 
 @RestController
 @RequestMapping("/api/mypage")
 @RequiredArgsConstructor
-public class MyPageController {
+public class MyPageController implements MyPageDocs {
   private final MyPageService myPageService;
 
+  @Override
   @GetMapping
   public ResponseEntity<ApiResponse<MyPageDto>> getUserInfo(
       @AuthenticationPrincipal UserPrincipalDto userDetails) {

--- a/src/main/java/com/example/dnd_13th_9_be/user/presentation/docs/MyPageDocs.java
+++ b/src/main/java/com/example/dnd_13th_9_be/user/presentation/docs/MyPageDocs.java
@@ -1,0 +1,55 @@
+package com.example.dnd_13th_9_be.user.presentation.docs;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import com.example.dnd_13th_9_be.global.response.ApiResponse;
+import com.example.dnd_13th_9_be.user.application.dto.MyPageDto;
+import com.example.dnd_13th_9_be.user.application.dto.UserPrincipalDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "마이 페이지", description = "마이 페이지(MyPage) 관련 API")
+public interface MyPageDocs {
+
+  @Operation(
+      summary = "내 정보 조회",
+      description =
+          """
+    카카오 서비스 인증을 거치지 않아 현재 이메일과 프로필 이미지는 제공되지 않습니다.
+    카카오에서 제공하는 **프로필 이름**을 `name`으로 반환합니다.
+    """)
+  @ApiResponses({
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "200",
+        description = "성공",
+        content =
+            @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ApiResponse.class),
+                examples =
+                    @ExampleObject(
+                        name = "성공 응답 예시",
+                        value =
+                            """
+                        {
+                          "code": "20000",
+                          "message": "성공했습니다",
+                          "data": {
+                            "name": "카카오프로필이름",
+                            "propertyCount": 12,
+                            "checklistCount": 3
+                          }
+                        }
+                        """)))
+  })
+  @GetMapping
+  ResponseEntity<ApiResponse<MyPageDto>> getUserInfo(
+      @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipalDto userDetails);
+}


### PR DESCRIPTION
# Changes 📝
closes #63 
- 마이페이지 UI를 구성하는데 필요한 데이터를 반환하는 API를 생성했습니다

# Screenshot
<img width="271" height="294" alt="스크린샷 2025-08-26 오후 10 00 23" src="https://github.com/user-attachments/assets/62d393db-e322-4b2e-8d82-f4ba548e480d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a My Page API endpoint that provides a consolidated snapshot of the signed-in user’s profile.
  - Returns the user’s display name, total number of saved properties, and total checklist items in a single response.
  - Uses the standard success response envelope for consistency across the app.
  - Enables clients to render personalized dashboards without multiple requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->