### PR TITLE
[FEATT] 매물 메모, 주변장소 메모 전체 리스트 조회

### DIFF
--- a/src/main/java/com/example/dnd_13th_9_be/folder/application/FolderService.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/application/FolderService.java
@@ -2,11 +2,6 @@ package com.example.dnd_13th_9_be.folder.application;
 
 import java.util.List;
 
-import com.example.dnd_13th_9_be.folder.presentation.dto.response.QueryFolderMemoListResponse;
-import com.example.dnd_13th_9_be.folder.presentation.dto.response.RecordSummaryResponse;
-import com.example.dnd_13th_9_be.placeMemo.application.dto.QueryPlaceMemoResponse;
-import com.example.dnd_13th_9_be.placeMemo.application.repository.PlaceMemoRepository;
-import com.example.dnd_13th_9_be.placeMemo.persistence.PlaceMemoRepositoryImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,7 +11,11 @@ import com.example.dnd_13th_9_be.folder.application.dto.FolderDetailResult;
 import com.example.dnd_13th_9_be.folder.application.dto.FolderSummaryResult;
 import com.example.dnd_13th_9_be.folder.application.dto.RecordSummaryResult;
 import com.example.dnd_13th_9_be.folder.application.repository.FolderRepository;
+import com.example.dnd_13th_9_be.folder.presentation.dto.response.QueryFolderMemoListResponse;
+import com.example.dnd_13th_9_be.folder.presentation.dto.response.RecordSummaryResponse;
 import com.example.dnd_13th_9_be.global.error.BusinessException;
+import com.example.dnd_13th_9_be.placeMemo.application.dto.QueryPlaceMemoResponse;
+import com.example.dnd_13th_9_be.placeMemo.application.repository.PlaceMemoRepository;
 import com.example.dnd_13th_9_be.plan.application.repository.PlanRepository;
 
 import static com.example.dnd_13th_9_be.global.error.ErrorCode.DEFAULT_FOLDER_CANNOT_BE_DELETE;
@@ -85,20 +84,18 @@ public class FolderService {
   }
 
   @Transactional
-  public QueryFolderMemoListResponse findAll(Long folderId, Long userId){
+  public QueryFolderMemoListResponse findAll(Long folderId, Long userId) {
 
     List<QueryPlaceMemoResponse> items =
-            placeMemoRepository.findByFolderIdAndUserId(folderId, userId).stream()
-                    .map(QueryPlaceMemoResponse::from)
-                    .toList();
+        placeMemoRepository.findByFolderIdAndUserId(folderId, userId).stream()
+            .map(QueryPlaceMemoResponse::from)
+            .toList();
 
     List<RecordSummaryResponse> records =
-            folderRepository.findAllRecordByIdAndUserId(userId, folderId).stream()
-                    .map(RecordSummaryResponse::from)
-                    .toList();
+        folderRepository.findAllRecordByIdAndUserId(userId, folderId).stream()
+            .map(RecordSummaryResponse::from)
+            .toList();
 
     return QueryFolderMemoListResponse.of(records, items);
   }
-
-
 }

--- a/src/main/java/com/example/dnd_13th_9_be/folder/application/FolderService.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/application/FolderService.java
@@ -2,6 +2,11 @@ package com.example.dnd_13th_9_be.folder.application;
 
 import java.util.List;
 
+import com.example.dnd_13th_9_be.folder.presentation.dto.response.QueryFolderMemoListResponse;
+import com.example.dnd_13th_9_be.folder.presentation.dto.response.RecordSummaryResponse;
+import com.example.dnd_13th_9_be.placeMemo.application.dto.QueryPlaceMemoResponse;
+import com.example.dnd_13th_9_be.placeMemo.application.repository.PlaceMemoRepository;
+import com.example.dnd_13th_9_be.placeMemo.persistence.PlaceMemoRepositoryImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +31,8 @@ public class FolderService {
   private final PlanRepository planRepository;
 
   private static final String DEFAULT_FOLDER_NAME = "기본 폴더";
+
+  private final PlaceMemoRepository placeMemoRepository;
 
   @Transactional
   public void createDefaultFolder(Long userId, Long planId) {
@@ -76,4 +83,22 @@ public class FolderService {
     folderRepository.verifyById(userId, folderId);
     return folderRepository.findAllRecordByIdAndUserId(userId, folderId);
   }
+
+  @Transactional
+  public QueryFolderMemoListResponse findAll(Long folderId, Long userId){
+
+    List<QueryPlaceMemoResponse> items =
+            placeMemoRepository.findByFolderIdAndUserId(folderId, userId).stream()
+                    .map(QueryPlaceMemoResponse::from)
+                    .toList();
+
+    List<RecordSummaryResponse> records =
+            folderRepository.findAllRecordByIdAndUserId(userId, folderId).stream()
+                    .map(RecordSummaryResponse::from)
+                    .toList();
+
+    return QueryFolderMemoListResponse.of(records, items);
+  }
+
+
 }

--- a/src/main/java/com/example/dnd_13th_9_be/folder/presentation/FolderController.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/presentation/FolderController.java
@@ -2,8 +2,6 @@ package com.example.dnd_13th_9_be.folder.presentation;
 
 import java.util.List;
 import java.util.Map;
-
-import com.example.dnd_13th_9_be.folder.presentation.dto.response.QueryFolderMemoListResponse;
 import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
@@ -25,6 +23,7 @@ import com.example.dnd_13th_9_be.folder.presentation.dto.request.CreateFolderReq
 import com.example.dnd_13th_9_be.folder.presentation.dto.request.RenameFolderRequest;
 import com.example.dnd_13th_9_be.folder.presentation.dto.response.FolderDetailResponse;
 import com.example.dnd_13th_9_be.folder.presentation.dto.response.FolderSummaryResponse;
+import com.example.dnd_13th_9_be.folder.presentation.dto.response.QueryFolderMemoListResponse;
 import com.example.dnd_13th_9_be.folder.presentation.dto.response.RecordSummaryResponse;
 import com.example.dnd_13th_9_be.global.response.ApiResponse;
 import com.example.dnd_13th_9_be.user.application.dto.UserPrincipalDto;
@@ -86,12 +85,12 @@ public class FolderController implements FolderDocs {
     return ApiResponse.successEntity(result);
   }
 
-
-  @GetMapping ("/{folderId}/memos") // 메물 메모 + 주변 장소 메모 조회
+  @GetMapping("/{folderId}/memos") // 메물 메모 + 주변 장소 메모 조회
   public ResponseEntity<ApiResponse<QueryFolderMemoListResponse>> findAll(
-          @AuthenticationPrincipal UserPrincipalDto userPrincipalDto,
-          @PathVariable("folderId") Long folderId) {
-    QueryFolderMemoListResponse response = folderService.findAll(folderId, userPrincipalDto.getUserId());
+      @AuthenticationPrincipal UserPrincipalDto userPrincipalDto,
+      @PathVariable("folderId") Long folderId) {
+    QueryFolderMemoListResponse response =
+        folderService.findAll(folderId, userPrincipalDto.getUserId());
     return ApiResponse.successEntity(response);
   }
 }

--- a/src/main/java/com/example/dnd_13th_9_be/folder/presentation/FolderController.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/presentation/FolderController.java
@@ -2,6 +2,8 @@ package com.example.dnd_13th_9_be.folder.presentation;
 
 import java.util.List;
 import java.util.Map;
+
+import com.example.dnd_13th_9_be.folder.presentation.dto.response.QueryFolderMemoListResponse;
 import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
@@ -73,7 +75,7 @@ public class FolderController implements FolderDocs {
   }
 
   @Override
-  @GetMapping("/{folderId}/records")
+  @GetMapping("/{folderId}/records") // 매물 메모 리스트 조회
   public ResponseEntity<ApiResponse<List<RecordSummaryResponse>>> getRecordList(
       @AuthenticationPrincipal UserPrincipalDto userDetails,
       @PathVariable("folderId") Long folderId) {
@@ -82,5 +84,14 @@ public class FolderController implements FolderDocs {
             .map(RecordSummaryResponse::from)
             .toList();
     return ApiResponse.successEntity(result);
+  }
+
+
+  @GetMapping ("/{folderId}/memos") // 메물 메모 + 주변 장소 메모 조회
+  public ResponseEntity<ApiResponse<QueryFolderMemoListResponse>> findAll(
+          @AuthenticationPrincipal UserPrincipalDto userPrincipalDto,
+          @PathVariable("folderId") Long folderId) {
+    QueryFolderMemoListResponse response = folderService.findAll(folderId, userPrincipalDto.getUserId());
+    return ApiResponse.successEntity(response);
   }
 }

--- a/src/main/java/com/example/dnd_13th_9_be/folder/presentation/docs/FolderDocs.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/presentation/docs/FolderDocs.java
@@ -448,7 +448,41 @@ public interface FolderDocs {
                                 "code": "20000",
                                 "message": "성공했습니다",
                                 "data": {
-                                  "placeMemos": [
+                                  "recordSummaryResponses": [
+                                    {
+                                      "id": 35,
+                                      "imageUrl": "https://zipzip-bucket.s3.amazonaws.com/images/58be7686-3fcb-4655-b3aa-fe9e713c0ab7.jpeg",
+                                      "recordType": "PROPERTY",
+                                      "feeling": "BAD",
+                                      "title": "안 괜찮은 원룸",
+                                      "contractType": "JEONSE",
+                                      "depositBig": 1,
+                                      "depositSmall": 2,
+                                      "managementFee": null,
+                                      "memo": "이 집은 될 수 있으면 피할 것!",
+                                      "locationTag": null,
+                                      "latitude": 35.098237529977,
+                                      "longitude": 128.981411608042,
+                                      "createdAt": "2025-08-25T00:11:17.844533"
+                                    },
+                                    {
+                                      "id": 34,
+                                      "imageUrl": null,
+                                      "recordType": "PROPERTY",
+                                      "feeling": "GOOD",
+                                      "title": "괜찮은 원룸",
+                                      "contractType": "MONTHLY_RENT",
+                                      "depositBig": 7,
+                                      "depositSmall": 10,
+                                      "managementFee": 10,
+                                      "memo": "제일 우선 순위",
+                                      "locationTag": null,
+                                      "latitude": 35.098237529973,
+                                      "longitude": 128.981411608041,
+                                      "createdAt": "2025-08-24T23:51:03.065649"
+                                    }
+                                  ],
+                                  "queryPlaceMemoResponses": [
                                     {
                                       "placeMemoId": 1,
                                       "title": "스타벅스 광안리점",
@@ -461,23 +495,6 @@ public interface FolderDocs {
                                         "https://zipzip-bucket.s3.amazonaws.com/images/starbucks1.jpg"
                                       ],
                                       "createdAt": "2025-08-26T14:30:22.123456"
-                                    }
-                                  ],
-                                  "propertyMemos": [
-                                    {
-                                      "propertyId": 2,
-                                      "title": "괜찮은 원룸",
-                                      "feeling": "GOOD",
-                                      "contractType": "MONTHLY_RENT",
-                                      "depositBig": 500,
-                                      "depositSmall": 30,
-                                      "managementFee": 10,
-                                      "memo": "제일 우선 순위로 고려할 것",
-                                      "address": "부산 해운대구 센텀남대로 35",
-                                      "latitude": 35.171877,
-                                      "longitude": 129.128654,
-                                      "imageUrl": "https://zipzip-bucket.s3.amazonaws.com/images/room1.jpg",
-                                      "createdAt": "2025-08-26T13:45:11.987654"
                                     }
                                   ]
                                 }

--- a/src/main/java/com/example/dnd_13th_9_be/folder/presentation/docs/FolderDocs.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/presentation/docs/FolderDocs.java
@@ -2,8 +2,6 @@ package com.example.dnd_13th_9_be.folder.presentation.docs;
 
 import java.util.List;
 import java.util.Map;
-
-import com.example.dnd_13th_9_be.folder.presentation.dto.response.QueryFolderMemoListResponse;
 import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
@@ -19,6 +17,7 @@ import com.example.dnd_13th_9_be.folder.presentation.dto.request.CreateFolderReq
 import com.example.dnd_13th_9_be.folder.presentation.dto.request.RenameFolderRequest;
 import com.example.dnd_13th_9_be.folder.presentation.dto.response.FolderDetailResponse;
 import com.example.dnd_13th_9_be.folder.presentation.dto.response.FolderSummaryResponse;
+import com.example.dnd_13th_9_be.folder.presentation.dto.response.QueryFolderMemoListResponse;
 import com.example.dnd_13th_9_be.folder.presentation.dto.response.RecordSummaryResponse;
 import com.example.dnd_13th_9_be.global.response.ApiResponse;
 import com.example.dnd_13th_9_be.user.application.dto.UserPrincipalDto;
@@ -431,20 +430,20 @@ public interface FolderDocs {
           @PathVariable("folderId")
           Long folderId);
 
-    @Operation(summary = "폴더 내 모든 메모 조회", description = "지정된 폴더에 포함된 주변장소 메모와 매물 메모를 모두 조회한다.")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200",
-                    description = "성공",
-                    content =
-                    @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = ApiResponse.class),
-                            examples =
-                            @ExampleObject(
-                                    name = "성공 예시",
-                                    value =
-                                            """
+  @Operation(summary = "폴더 내 모든 메모 조회", description = "지정된 폴더에 포함된 주변장소 메모와 매물 메모를 모두 조회한다.")
+  @ApiResponses({
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "200",
+        description = "성공",
+        content =
+            @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ApiResponse.class),
+                examples =
+                    @ExampleObject(
+                        name = "성공 예시",
+                        value =
+                            """
                               {
                                 "code": "20000",
                                 "message": "성공했습니다",
@@ -484,46 +483,47 @@ public interface FolderDocs {
                                 }
                               }
                               """))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "404",
-                    description = "유효하지 않은 폴더 id",
-                    content =
-                    @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = ApiResponse.class),
-                            examples =
-                            @ExampleObject(
-                                    name = "폴더 없음 예시",
-                                    value =
-                                            """
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "404",
+        description = "유효하지 않은 폴더 id",
+        content =
+            @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ApiResponse.class),
+                examples =
+                    @ExampleObject(
+                        name = "폴더 없음 예시",
+                        value =
+                            """
                               {
                                 "code": "72000",
                                 "message": "유효하지 않은 폴더입니다",
                                 "data": null
                               }
                               """))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "403",
-                    description = "폴더 접근 권한 없음",
-                    content =
-                    @Content(
-                            mediaType = "application/json",
-                            schema = @Schema(implementation = ApiResponse.class),
-                            examples =
-                            @ExampleObject(
-                                    name = "권한 없음 예시",
-                                    value =
-                                            """
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "403",
+        description = "폴더 접근 권한 없음",
+        content =
+            @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ApiResponse.class),
+                examples =
+                    @ExampleObject(
+                        name = "권한 없음 예시",
+                        value =
+                            """
                               {
                                 "code": "40300",
                                 "message": "해당 폴더에 접근할 권한이 없습니다",
                                 "data": null
                               }
                               """)))
-    })
-    @GetMapping("/{folderId}/memos")
-    ResponseEntity<ApiResponse<QueryFolderMemoListResponse>> findAll(
-            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipalDto userDetails,
-            @Parameter(description = "폴더 고유 인덱스 값", example = "12", required = true)
-            @PathVariable("folderId") Long folderId);
+  })
+  @GetMapping("/{folderId}/memos")
+  ResponseEntity<ApiResponse<QueryFolderMemoListResponse>> findAll(
+      @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipalDto userDetails,
+      @Parameter(description = "폴더 고유 인덱스 값", example = "12", required = true)
+          @PathVariable("folderId")
+          Long folderId);
 }

--- a/src/main/java/com/example/dnd_13th_9_be/folder/presentation/docs/FolderDocs.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/presentation/docs/FolderDocs.java
@@ -2,6 +2,8 @@ package com.example.dnd_13th_9_be.folder.presentation.docs;
 
 import java.util.List;
 import java.util.Map;
+
+import com.example.dnd_13th_9_be.folder.presentation.dto.response.QueryFolderMemoListResponse;
 import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
@@ -428,4 +430,100 @@ public interface FolderDocs {
       @Parameter(description = "폴더 고유 인덱스 값", example = "12", required = true)
           @PathVariable("folderId")
           Long folderId);
+
+    @Operation(summary = "폴더 내 모든 메모 조회", description = "지정된 폴더에 포함된 주변장소 메모와 매물 메모를 모두 조회한다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성공",
+                    content =
+                    @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples =
+                            @ExampleObject(
+                                    name = "성공 예시",
+                                    value =
+                                            """
+                              {
+                                "code": "20000",
+                                "message": "성공했습니다",
+                                "data": {
+                                  "placeMemos": [
+                                    {
+                                      "placeMemoId": 1,
+                                      "title": "스타벅스 광안리점",
+                                      "placeTag": "CONVENIENCE",
+                                      "description": "회의하기 좋은 카페",
+                                      "address": "부산 수영구 광안해변로 219",
+                                      "latitude": 35.153495,
+                                      "longitude": 129.118666,
+                                      "images": [
+                                        "https://zipzip-bucket.s3.amazonaws.com/images/starbucks1.jpg"
+                                      ],
+                                      "createdAt": "2025-08-26T14:30:22.123456"
+                                    }
+                                  ],
+                                  "propertyMemos": [
+                                    {
+                                      "propertyId": 2,
+                                      "title": "괜찮은 원룸",
+                                      "feeling": "GOOD",
+                                      "contractType": "MONTHLY_RENT",
+                                      "depositBig": 500,
+                                      "depositSmall": 30,
+                                      "managementFee": 10,
+                                      "memo": "제일 우선 순위로 고려할 것",
+                                      "address": "부산 해운대구 센텀남대로 35",
+                                      "latitude": 35.171877,
+                                      "longitude": 129.128654,
+                                      "imageUrl": "https://zipzip-bucket.s3.amazonaws.com/images/room1.jpg",
+                                      "createdAt": "2025-08-26T13:45:11.987654"
+                                    }
+                                  ]
+                                }
+                              }
+                              """))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "유효하지 않은 폴더 id",
+                    content =
+                    @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples =
+                            @ExampleObject(
+                                    name = "폴더 없음 예시",
+                                    value =
+                                            """
+                              {
+                                "code": "72000",
+                                "message": "유효하지 않은 폴더입니다",
+                                "data": null
+                              }
+                              """))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "폴더 접근 권한 없음",
+                    content =
+                    @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ApiResponse.class),
+                            examples =
+                            @ExampleObject(
+                                    name = "권한 없음 예시",
+                                    value =
+                                            """
+                              {
+                                "code": "40300",
+                                "message": "해당 폴더에 접근할 권한이 없습니다",
+                                "data": null
+                              }
+                              """)))
+    })
+    @GetMapping("/{folderId}/memos")
+    ResponseEntity<ApiResponse<QueryFolderMemoListResponse>> findAll(
+            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipalDto userDetails,
+            @Parameter(description = "폴더 고유 인덱스 값", example = "12", required = true)
+            @PathVariable("folderId") Long folderId);
 }

--- a/src/main/java/com/example/dnd_13th_9_be/folder/presentation/dto/response/QueryFolderMemoListResponse.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/presentation/dto/response/QueryFolderMemoListResponse.java
@@ -1,0 +1,15 @@
+package com.example.dnd_13th_9_be.folder.presentation.dto.response;
+
+import com.example.dnd_13th_9_be.placeMemo.application.dto.QueryPlaceMemoListResponse;
+import com.example.dnd_13th_9_be.placeMemo.application.dto.QueryPlaceMemoResponse;
+
+import java.util.List;
+
+public record QueryFolderMemoListResponse(List<RecordSummaryResponse> recordSummaryResponses,
+        List<QueryPlaceMemoResponse> queryPlaceMemoResponses)
+{
+    public static QueryFolderMemoListResponse of(List<RecordSummaryResponse> recordSummaryResponses,
+                                                 List<QueryPlaceMemoResponse> queryPlaceMemoResponses){
+        return new QueryFolderMemoListResponse(recordSummaryResponses, queryPlaceMemoResponses);
+    }
+}

--- a/src/main/java/com/example/dnd_13th_9_be/folder/presentation/dto/response/QueryFolderMemoListResponse.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/presentation/dto/response/QueryFolderMemoListResponse.java
@@ -1,15 +1,15 @@
 package com.example.dnd_13th_9_be.folder.presentation.dto.response;
 
-import com.example.dnd_13th_9_be.placeMemo.application.dto.QueryPlaceMemoListResponse;
-import com.example.dnd_13th_9_be.placeMemo.application.dto.QueryPlaceMemoResponse;
-
 import java.util.List;
 
-public record QueryFolderMemoListResponse(List<RecordSummaryResponse> recordSummaryResponses,
-        List<QueryPlaceMemoResponse> queryPlaceMemoResponses)
-{
-    public static QueryFolderMemoListResponse of(List<RecordSummaryResponse> recordSummaryResponses,
-                                                 List<QueryPlaceMemoResponse> queryPlaceMemoResponses){
-        return new QueryFolderMemoListResponse(recordSummaryResponses, queryPlaceMemoResponses);
-    }
+import com.example.dnd_13th_9_be.placeMemo.application.dto.QueryPlaceMemoResponse;
+
+public record QueryFolderMemoListResponse(
+    List<RecordSummaryResponse> recordSummaryResponses,
+    List<QueryPlaceMemoResponse> queryPlaceMemoResponses) {
+  public static QueryFolderMemoListResponse of(
+      List<RecordSummaryResponse> recordSummaryResponses,
+      List<QueryPlaceMemoResponse> queryPlaceMemoResponses) {
+    return new QueryFolderMemoListResponse(recordSummaryResponses, queryPlaceMemoResponses);
+  }
 }


### PR DESCRIPTION
## 주요기능
closes #62 
- 특정 폴더의 매물 메모, 주변장소 메모 리스트를 전체 조회 하는 api 입니다.

## to 리뷰어
- 기존 매물 메모 리스트 조회, 주변장소 리스트 조회는 남겨두고 추가 api로 개발했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GET /{folderId}/memos to retrieve all memos in a folder for the authenticated user.
  * Response now combines place memos and record summaries into a single payload.
  * Service now aggregates memos and records; new combined response type introduced.

* **Documentation**
  * API docs updated for the new memos endpoint with success and error examples (200, 403, 404).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->