### PR TITLE
[FEAT] 폴더 별 매물 메모, 주변장소 메모 개수 count API

### DIFF
--- a/src/main/java/com/example/dnd_13th_9_be/folder/persistence/QueryDslFolderRepositoryImpl.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/persistence/QueryDslFolderRepositoryImpl.java
@@ -3,8 +3,6 @@ package com.example.dnd_13th_9_be.folder.persistence;
 import java.util.List;
 import java.util.Optional;
 
-import com.example.dnd_13th_9_be.placeMemo.persistence.QPlaceMemo;
-import com.querydsl.jpa.JPQLQuery;
 import lombok.RequiredArgsConstructor;
 
 import com.example.dnd_13th_9_be.folder.persistence.dto.FolderSummary;
@@ -12,11 +10,13 @@ import com.example.dnd_13th_9_be.folder.persistence.dto.RecordSummary;
 import com.example.dnd_13th_9_be.folder.persistence.entity.QFolder;
 import com.example.dnd_13th_9_be.folder.persistence.entity.RecordType;
 import com.example.dnd_13th_9_be.location.persistence.QLocationRecordEntity;
+import com.example.dnd_13th_9_be.placeMemo.persistence.QPlaceMemo;
 import com.example.dnd_13th_9_be.property.persistence.entity.QProperty;
 import com.example.dnd_13th_9_be.property.persistence.entity.QPropertyImage;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import static com.querydsl.core.group.GroupBy.groupBy;
@@ -33,10 +33,10 @@ public class QueryDslFolderRepositoryImpl implements QueryDslFolderRepository {
 
     QPlaceMemo placeMemo = QPlaceMemo.placeMemo;
 
-    JPQLQuery<Long> placeMemoCnt = JPAExpressions.select(placeMemo.id.count())
+    JPQLQuery<Long> placeMemoCnt =
+        JPAExpressions.select(placeMemo.id.count())
             .from(placeMemo)
             .where(placeMemo.folder.id.eq(folder.id));
-
 
     var propertyCnt =
         JPAExpressions.select(property.id.count())

--- a/src/main/java/com/example/dnd_13th_9_be/folder/persistence/QueryDslFolderRepositoryImpl.java
+++ b/src/main/java/com/example/dnd_13th_9_be/folder/persistence/QueryDslFolderRepositoryImpl.java
@@ -3,6 +3,8 @@ package com.example.dnd_13th_9_be.folder.persistence;
 import java.util.List;
 import java.util.Optional;
 
+import com.example.dnd_13th_9_be.placeMemo.persistence.QPlaceMemo;
+import com.querydsl.jpa.JPQLQuery;
 import lombok.RequiredArgsConstructor;
 
 import com.example.dnd_13th_9_be.folder.persistence.dto.FolderSummary;
@@ -27,13 +29,14 @@ public class QueryDslFolderRepositoryImpl implements QueryDslFolderRepository {
   @Override
   public List<FolderSummary> findSummariesByPlanId(Long userId, Long planId) {
     var folder = QFolder.folder;
-    var location = QLocationRecordEntity.locationRecordEntity;
     var property = QProperty.property;
 
-    var locationCnt =
-        JPAExpressions.select(location.id.count())
-            .from(location)
-            .where(location.folder.id.eq(folder.id));
+    QPlaceMemo placeMemo = QPlaceMemo.placeMemo;
+
+    JPQLQuery<Long> placeMemoCnt = JPAExpressions.select(placeMemo.id.count())
+            .from(placeMemo)
+            .where(placeMemo.folder.id.eq(folder.id));
+
 
     var propertyCnt =
         JPAExpressions.select(property.id.count())
@@ -47,7 +50,7 @@ public class QueryDslFolderRepositoryImpl implements QueryDslFolderRepository {
                 folder.id,
                 folder.name,
                 folder.createdAt,
-                locationCnt,
+                placeMemoCnt,
                 propertyCnt,
                 folder.isDefault))
         .from(folder)


### PR DESCRIPTION
### 주요 변경사항
closes #68 
폴더별 매물 메모와 주변장소 메모의 총 개수를 기존 폴더 리스트 조회 응답에 추가했습니다.