### PR TITLE
feat : 로그아웃 토큰 삭제 로직추가

### DIFF
--- a/src/main/java/com/example/dnd_13th_9_be/user/presentation/UserController.java
+++ b/src/main/java/com/example/dnd_13th_9_be/user/presentation/UserController.java
@@ -46,6 +46,7 @@ public class UserController {
     Optional<Cookie> refreshCookie = cookieUtil.find(request.getCookies(), "Refresh");
     refreshCookie.ifPresent(cookie -> refreshTokenService.deleteByToken(cookie.getValue()));
     response.addCookie(cookieUtil.remove("Refresh"));
+    response.addCookie(cookieUtil.remove("Access"));
     return ResponseEntity.ok(ApiResponse.success("로그아웃 완료"));
   }
 


### PR DESCRIPTION
closes #78 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Logout now also clears the Access cookie in addition to the Refresh token, ensuring a complete sign-out.
  * Prevents cases where users appeared still logged in after logout due to lingering access credentials.
  * No UI changes; the logout flow remains the same, with improved cleanup for consistency across sessions and browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->