### PR TITLE
[FEAT] 매물 메모 공유하기 기능 구현

### DIFF
--- a/src/main/java/com/example/dnd_13th_9_be/common/cipher/AESCipherUtil.java
+++ b/src/main/java/com/example/dnd_13th_9_be/common/cipher/AESCipherUtil.java
@@ -1,6 +1,8 @@
 package com.example.dnd_13th_9_be.common.cipher;
 
 import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Arrays;
 import java.util.Base64;
 import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
@@ -21,18 +23,24 @@ public class AESCipherUtil implements CipherUtil {
 
   public static String CIPHER_ALGORITHM = "AES/CBC/PKCS5Padding";
   public static String SECRET_KEY_ALGORITHM = "AES";
+  private static final int IV_LENGTH = 16;
 
   @Override
   public String encode(String plainText) {
     try {
       final SecretKeySpec keySpec = new SecretKeySpec(privateKey.getBytes(), SECRET_KEY_ALGORITHM);
-      final IvParameterSpec IV = new IvParameterSpec(privateKey.substring(0, 16).getBytes());
+      final byte[] iv = new byte[16];
+      new SecureRandom().nextBytes(iv);
+      final IvParameterSpec ivSpec = new IvParameterSpec(iv);
 
       final Cipher cipher = Cipher.getInstance(CIPHER_ALGORITHM);
-      cipher.init(Cipher.ENCRYPT_MODE, keySpec, IV);
+      cipher.init(Cipher.ENCRYPT_MODE, keySpec, ivSpec);
 
-      byte[] encrypted = cipher.doFinal(plainText.getBytes(StandardCharsets.UTF_8));
-      return Base64.getEncoder().encodeToString(encrypted);
+      final byte[] cipherText = cipher.doFinal(plainText.getBytes(StandardCharsets.UTF_8));
+      final byte[] out = new byte[iv.length + cipherText.length];
+      System.arraycopy(iv, 0, out, 0, iv.length);
+      System.arraycopy(cipherText, 0, out, iv.length, cipherText.length);
+      return Base64.getEncoder().encodeToString(out);
     } catch (Exception e) {
       throw new BusinessException(CIPHER_ENCODE_ERROR);
     }
@@ -41,15 +49,23 @@ public class AESCipherUtil implements CipherUtil {
   @Override
   public String decode(String encodedText) {
     try {
-      final SecretKeySpec keySpec = new SecretKeySpec(privateKey.getBytes(), SECRET_KEY_ALGORITHM);
-      final IvParameterSpec IV = new IvParameterSpec(privateKey.substring(0, 16).getBytes());
+      final byte[] keyBytes = privateKey.getBytes(StandardCharsets.UTF_8);
+      if (!(keyBytes.length == 16 || keyBytes.length == 24 || keyBytes.length == 32)) {
+        throw new BusinessException(CIPHER_DECODE_ERROR);
+      }
+      final SecretKeySpec keySpec = new SecretKeySpec(keyBytes, SECRET_KEY_ALGORITHM);
+
+      final byte[] all = Base64.getDecoder().decode(encodedText);
+      if (all.length < 17) {
+        throw new BusinessException(CIPHER_DECODE_ERROR);
+      }
+      final byte[] iv = Arrays.copyOfRange(all, 0, 16);
+      final byte[] cipherText = Arrays.copyOfRange(all, 16, all.length);
 
       final Cipher cipher = Cipher.getInstance(CIPHER_ALGORITHM);
-      cipher.init(Cipher.DECRYPT_MODE, keySpec, IV);
-
-      byte[] decodedBytes = Base64.getDecoder().decode(encodedText);
-      byte[] decrypted = cipher.doFinal(decodedBytes);
-      return new String(decrypted, StandardCharsets.UTF_8);
+      cipher.init(Cipher.DECRYPT_MODE, keySpec, new IvParameterSpec(iv));
+      final byte[] plain = cipher.doFinal(cipherText);
+      return new String(plain, StandardCharsets.UTF_8);
     } catch (Exception e) {
       throw new BusinessException(CIPHER_DECODE_ERROR);
     }

--- a/src/main/java/com/example/dnd_13th_9_be/common/cipher/AESCipherUtil.java
+++ b/src/main/java/com/example/dnd_13th_9_be/common/cipher/AESCipherUtil.java
@@ -29,7 +29,7 @@ public class AESCipherUtil implements CipherUtil {
       final IvParameterSpec IV = new IvParameterSpec(privateKey.substring(0, 16).getBytes());
 
       final Cipher cipher = Cipher.getInstance(CIPHER_ALGORITHM);
-      cipher.init(Cipher.DECRYPT_MODE, keySpec, IV);
+      cipher.init(Cipher.ENCRYPT_MODE, keySpec, IV);
 
       byte[] encrypted = cipher.doFinal(plainText.getBytes(StandardCharsets.UTF_8));
       return Base64.getEncoder().encodeToString(encrypted);

--- a/src/main/java/com/example/dnd_13th_9_be/common/cipher/AESCipherUtil.java
+++ b/src/main/java/com/example/dnd_13th_9_be/common/cipher/AESCipherUtil.java
@@ -1,0 +1,22 @@
+package com.example.dnd_13th_9_be.common.cipher;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AESCipherUtil implements CipherUtil {
+    @Value("${aes.private-key}")
+    private String privateKey;
+
+    public static String ALGORITHMS = "AES/CBC/PKCS5Padding";
+
+    @Override
+    public String encode(String plainText) {
+        return null;
+    }
+
+    @Override
+    public String decode(String encodedText) {
+        return null;
+    }
+}

--- a/src/main/java/com/example/dnd_13th_9_be/common/cipher/AESCipherUtil.java
+++ b/src/main/java/com/example/dnd_13th_9_be/common/cipher/AESCipherUtil.java
@@ -1,22 +1,57 @@
 package com.example.dnd_13th_9_be.common.cipher;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import com.example.dnd_13th_9_be.global.error.BusinessException;
+
+import static com.example.dnd_13th_9_be.global.error.ErrorCode.CIPHER_DECODE_ERROR;
+import static com.example.dnd_13th_9_be.global.error.ErrorCode.CIPHER_ENCODE_ERROR;
+
 @Component
 public class AESCipherUtil implements CipherUtil {
-    @Value("${aes.private-key}")
-    private String privateKey;
+  @Value("${aes.private-key}")
+  private String privateKey;
 
-    public static String ALGORITHMS = "AES/CBC/PKCS5Padding";
+  public static String CIPHER_ALGORITHM = "AES/CBC/PKCS5Padding";
+  public static String SECRET_KEY_ALGORITHM = "AES";
 
-    @Override
-    public String encode(String plainText) {
-        return null;
+  @Override
+  public String encode(String plainText) {
+    try {
+      final SecretKeySpec keySpec = new SecretKeySpec(privateKey.getBytes(), SECRET_KEY_ALGORITHM);
+      final IvParameterSpec IV = new IvParameterSpec(privateKey.substring(0, 16).getBytes());
+
+      final Cipher cipher = Cipher.getInstance(CIPHER_ALGORITHM);
+      cipher.init(Cipher.DECRYPT_MODE, keySpec, IV);
+
+      byte[] encrypted = cipher.doFinal(plainText.getBytes(StandardCharsets.UTF_8));
+      return Base64.getEncoder().encodeToString(encrypted);
+    } catch (Exception e) {
+      throw new BusinessException(CIPHER_ENCODE_ERROR);
     }
+  }
 
-    @Override
-    public String decode(String encodedText) {
-        return null;
+  @Override
+  public String decode(String encodedText) {
+    try {
+      final SecretKeySpec keySpec = new SecretKeySpec(privateKey.getBytes(), SECRET_KEY_ALGORITHM);
+      final IvParameterSpec IV = new IvParameterSpec(privateKey.substring(0, 16).getBytes());
+
+      final Cipher cipher = Cipher.getInstance(CIPHER_ALGORITHM);
+      cipher.init(Cipher.DECRYPT_MODE, keySpec, IV);
+
+      byte[] decodedBytes = Base64.getDecoder().decode(encodedText);
+      byte[] decrypted = cipher.doFinal(decodedBytes);
+      return new String(decrypted, StandardCharsets.UTF_8);
+    } catch (Exception e) {
+      throw new BusinessException(CIPHER_DECODE_ERROR);
     }
+  }
 }

--- a/src/main/java/com/example/dnd_13th_9_be/common/cipher/CipherUtil.java
+++ b/src/main/java/com/example/dnd_13th_9_be/common/cipher/CipherUtil.java
@@ -1,0 +1,6 @@
+package com.example.dnd_13th_9_be.common.cipher;
+
+public interface CipherUtil {
+    String encode(String plainText);
+    String decode(String encodedText);
+}

--- a/src/main/java/com/example/dnd_13th_9_be/common/cipher/CipherUtil.java
+++ b/src/main/java/com/example/dnd_13th_9_be/common/cipher/CipherUtil.java
@@ -1,6 +1,7 @@
 package com.example.dnd_13th_9_be.common.cipher;
 
 public interface CipherUtil {
-    String encode(String plainText);
-    String decode(String encodedText);
+  String encode(String plainText);
+
+  String decode(String encodedText);
 }

--- a/src/main/java/com/example/dnd_13th_9_be/common/utils/JsonUtil.java
+++ b/src/main/java/com/example/dnd_13th_9_be/common/utils/JsonUtil.java
@@ -1,0 +1,27 @@
+package com.example.dnd_13th_9_be.common.utils;
+
+import com.example.dnd_13th_9_be.global.error.BusinessException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import static com.example.dnd_13th_9_be.global.error.ErrorCode.JSON_PROCESSING_ERROR;
+
+public class JsonUtil {
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  public static String toJson(Object obj) {
+    try {
+      return objectMapper.writeValueAsString(obj);
+    } catch (JsonProcessingException e) {
+      throw new BusinessException(JSON_PROCESSING_ERROR);
+    }
+  }
+
+  public static <T> T fromJson(String json, Class<T> clazz) {
+    try {
+      return objectMapper.readValue(json, clazz);
+    } catch (JsonProcessingException e) {
+      throw new BusinessException(JSON_PROCESSING_ERROR);
+    }
+  }
+}

--- a/src/main/java/com/example/dnd_13th_9_be/config/security/JWTFilter.java
+++ b/src/main/java/com/example/dnd_13th_9_be/config/security/JWTFilter.java
@@ -41,7 +41,7 @@ public class JWTFilter extends OncePerRequestFilter {
         || request.getRequestURI().startsWith("/oauth2/authorization")
         || request.getRequestURI().equals("/api/auth/refresh")
         || request.getRequestURI().equals("/api/test/auth/token")
-        || request.getRequestURI().startsWith("/api/property/share")) {
+        || request.getRequestURI().startsWith("/api/property/share/")) {
       filterChain.doFilter(request, response);
       return;
     }

--- a/src/main/java/com/example/dnd_13th_9_be/config/security/JWTFilter.java
+++ b/src/main/java/com/example/dnd_13th_9_be/config/security/JWTFilter.java
@@ -40,7 +40,8 @@ public class JWTFilter extends OncePerRequestFilter {
         || request.getRequestURI().startsWith("/login/oauth2/")
         || request.getRequestURI().startsWith("/oauth2/authorization")
         || request.getRequestURI().equals("/api/auth/refresh")
-        || request.getRequestURI().equals("/api/test/auth/token")) {
+        || request.getRequestURI().equals("/api/test/auth/token")
+        || request.getRequestURI().startsWith("/api/property/share")) {
       filterChain.doFilter(request, response);
       return;
     }

--- a/src/main/java/com/example/dnd_13th_9_be/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/dnd_13th_9_be/config/security/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.example.dnd_13th_9_be.config.security;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -70,6 +71,8 @@ public class SecurityConfig {
         .authorizeHttpRequests(
             authorize ->
                 authorize
+                    .requestMatchers(HttpMethod.GET, "/api/property/share/**")
+                    .permitAll()
                     .requestMatchers(
                         "/oauth2/**",
                         "/login/oauth2/**",

--- a/src/main/java/com/example/dnd_13th_9_be/global/error/ErrorCode.java
+++ b/src/main/java/com/example/dnd_13th_9_be/global/error/ErrorCode.java
@@ -37,6 +37,9 @@ public enum ErrorCode implements ResponseCode {
   CIPHER_ENCODE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "51000", "암호화에 실패했습니다"),
   CIPHER_DECODE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "51001", "복호화에 실패했습니다"),
 
+  // json error 52000
+  JSON_PROCESSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "52000", "json<->string 변환에 실패했습니다"),
+
   // plan 71xxx,
   NOT_FOUND_PLAN(HttpStatus.NOT_FOUND, "71000", "유효하지 않은 계획입니다"),
   PLAN_CREATION_LIMIT(HttpStatus.BAD_REQUEST, "71001", "최대 생성할 수 있는 계획 갯수를 초과했습니다"),

--- a/src/main/java/com/example/dnd_13th_9_be/global/error/ErrorCode.java
+++ b/src/main/java/com/example/dnd_13th_9_be/global/error/ErrorCode.java
@@ -29,9 +29,13 @@ public enum ErrorCode implements ResponseCode {
   USER_NOT_FOUND(HttpStatus.NOT_FOUND, "60000", "해당 id에 맞는 유저가 없습니다"),
   USER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "60001", "권한이 없습니다"),
 
-  // server error
+  // server error 50000
   INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "50000", "서버 내부 오류입니다"),
   SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "50300", "일시적으로 이용할 수 없습니다"),
+
+  // cipher error 51000
+  CIPHER_ENCODE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "51000", "암호화에 실패했습니다"),
+  CIPHER_DECODE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "51001", "복호화에 실패했습니다"),
 
   // plan 71xxx,
   NOT_FOUND_PLAN(HttpStatus.NOT_FOUND, "71000", "유효하지 않은 계획입니다"),

--- a/src/main/java/com/example/dnd_13th_9_be/property/presentation/PropertyController.java
+++ b/src/main/java/com/example/dnd_13th_9_be/property/presentation/PropertyController.java
@@ -19,12 +19,16 @@ import org.springframework.web.multipart.MultipartFile;
 
 import lombok.RequiredArgsConstructor;
 
+import com.example.dnd_13th_9_be.common.cipher.AESCipherUtil;
+import com.example.dnd_13th_9_be.common.utils.JsonUtil;
 import com.example.dnd_13th_9_be.global.response.ApiResponse;
 import com.example.dnd_13th_9_be.property.application.PropertyService;
 import com.example.dnd_13th_9_be.property.application.model.RecentPropertyModel;
 import com.example.dnd_13th_9_be.property.presentation.docs.PropertyDocs;
+import com.example.dnd_13th_9_be.property.presentation.dto.request.SharePropertyRequest;
 import com.example.dnd_13th_9_be.property.presentation.dto.request.UpsertPropertyRequest;
 import com.example.dnd_13th_9_be.property.presentation.dto.response.PropertyDetailResponse;
+import com.example.dnd_13th_9_be.property.presentation.dto.response.SharePropertyResponse;
 import com.example.dnd_13th_9_be.user.application.dto.UserPrincipalDto;
 
 @Validated
@@ -33,6 +37,7 @@ import com.example.dnd_13th_9_be.user.application.dto.UserPrincipalDto;
 @RequestMapping("/api/property")
 public class PropertyController implements PropertyDocs {
   private final PropertyService propertyService;
+  private final AESCipherUtil aesCipherUtil;
 
   @Override
   @PostMapping
@@ -83,5 +88,19 @@ public class PropertyController implements PropertyDocs {
     List<RecentPropertyModel> result =
         propertyService.findTopByUserId(userDetails.getUserId(), size);
     return ApiResponse.successEntity(result);
+  }
+
+  @GetMapping("/sharelink/{propertyId}")
+  public ResponseEntity<ApiResponse<SharePropertyResponse>> getShareLink(
+      @AuthenticationPrincipal UserPrincipalDto userDetails,
+      @PathVariable("propertyId") Long propertyId) {
+    SharePropertyRequest request =
+        SharePropertyRequest.builder()
+            .userId(userDetails.getUserId())
+            .propertyId(propertyId)
+            .build();
+    String requestString = JsonUtil.toJson(request);
+    String encryptedString = aesCipherUtil.encode(requestString);
+    return ApiResponse.successEntity(new SharePropertyResponse(encryptedString));
   }
 }

--- a/src/main/java/com/example/dnd_13th_9_be/property/presentation/PropertyController.java
+++ b/src/main/java/com/example/dnd_13th_9_be/property/presentation/PropertyController.java
@@ -90,6 +90,7 @@ public class PropertyController implements PropertyDocs {
     return ApiResponse.successEntity(result);
   }
 
+  @Override
   @GetMapping("/sharelink/{propertyId}")
   public ResponseEntity<ApiResponse<SharePropertyResponse>> getShareLink(
       @AuthenticationPrincipal UserPrincipalDto userDetails,

--- a/src/main/java/com/example/dnd_13th_9_be/property/presentation/PropertyShareController.java
+++ b/src/main/java/com/example/dnd_13th_9_be/property/presentation/PropertyShareController.java
@@ -1,5 +1,6 @@
 package com.example.dnd_13th_9_be.property.presentation;
 
+import com.example.dnd_13th_9_be.property.presentation.docs.PropertyShareDocs;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,10 +21,11 @@ import com.example.dnd_13th_9_be.property.presentation.dto.response.PropertyDeta
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/property/share")
-public class PropertyShareController {
+public class PropertyShareController implements PropertyShareDocs {
   private final PropertyService propertyService;
   private final AESCipherUtil aesCipherUtil;
 
+  @Override
   @GetMapping("/{shareLink}")
   public ResponseEntity<ApiResponse<PropertyDetailResponse>> getProperty(
       @PathVariable("shareLink") String shareLink) {

--- a/src/main/java/com/example/dnd_13th_9_be/property/presentation/PropertyShareController.java
+++ b/src/main/java/com/example/dnd_13th_9_be/property/presentation/PropertyShareController.java
@@ -1,0 +1,36 @@
+package com.example.dnd_13th_9_be.property.presentation;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+import com.example.dnd_13th_9_be.common.cipher.AESCipherUtil;
+import com.example.dnd_13th_9_be.common.utils.JsonUtil;
+import com.example.dnd_13th_9_be.global.response.ApiResponse;
+import com.example.dnd_13th_9_be.property.application.PropertyService;
+import com.example.dnd_13th_9_be.property.presentation.dto.request.SharePropertyRequest;
+import com.example.dnd_13th_9_be.property.presentation.dto.response.PropertyDetailResponse;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/property/share")
+public class PropertyShareController {
+  private final PropertyService propertyService;
+  private final AESCipherUtil aesCipherUtil;
+
+  @GetMapping("/{shareLink}")
+  public ResponseEntity<ApiResponse<PropertyDetailResponse>> getProperty(
+      @PathVariable("shareLink") String shareLink) {
+    String decrypted = aesCipherUtil.decode(shareLink);
+    SharePropertyRequest request = JsonUtil.fromJson(decrypted, SharePropertyRequest.class);
+    PropertyDetailResponse response =
+        propertyService.getProperty(request.userId(), request.propertyId());
+    return ApiResponse.successEntity(response);
+  }
+}

--- a/src/main/java/com/example/dnd_13th_9_be/property/presentation/docs/PropertyDocs.java
+++ b/src/main/java/com/example/dnd_13th_9_be/property/presentation/docs/PropertyDocs.java
@@ -1,5 +1,6 @@
 package com.example.dnd_13th_9_be.property.presentation.docs;
 
+import com.example.dnd_13th_9_be.property.presentation.dto.response.SharePropertyResponse;
 import java.util.List;
 import java.util.Map;
 
@@ -545,4 +546,77 @@ public interface PropertyDocs {
       @Parameter(name = "size", description = "응답 받을 매물 메모 갯수 (기본값 10, 옵션)", example = "5")
           @RequestParam(name = "size", defaultValue = "10")
           int size);
+
+    @Operation(
+        summary = "매물 공유 링크 생성",
+        description =
+            """
+                1. `/api/property/sharelink/{propertyId}` api를 호출해서 응답의 `shareLink`라는 토큰 값을 얻습니다.
+                2. 클라이언트는 로그인 하지 않은 사용자에게 매물 메모를 보여줄 화면 url을 가지고 있을 겁니다. 이 url과 sharedLink 토큰을 조합하여 사용자에게 공유합니다. (ex: 만약 매물 메모 공유 화면 링크가 [www.zipzip.cloud/share/property](http://www.zipzip.cloud/share/property) 일경우 www.zipzip.cloud/share/property/{shareLink} 와 같은 url을 사용자에게 전달합니다. 이 부분은 클라이언트 부분이므로 프론트에서 작업하시기 편리한 방법을 선택하시면 됩니다.)
+                3. 로그인 하지 않은 사용자는 매물 메모 공유 링크를 가지고 해당 웹페이지로 접근합니다.
+                4. 클라이언트는 사용자가 접속한 링크에서 sharedLink 부분을 얻어, `/api/property/share/{shareLink}` api로 전달 주세요. 해당 api문서는 [매물 메모 공유 화면 데이터 조회](https://www.notion.so/25cb87ed31df80a39b20c7f5ce6af65f?pvs=21) 입니다.
+                5. 매물 메모 공유 테스트 할때는 access 토큰과 refresh 토큰 없이 확인해 주세요!
+            """)
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "성공 (공유 토큰 발급)",
+            content =
+            @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ApiResponse.class),
+                examples =
+                @ExampleObject(
+                    name = "성공 예시",
+                    value =
+                        """
+                        {
+                          "code": "20000",
+                          "message": "성공했습니다",
+                          "data": {
+                            "shareLink": "CMtqt3YkUo7ar3NrHyLIs279YVSMfn5sK9GnPy56UFE="
+                          }
+                        }
+                        """))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "401",
+            description = "인증 실패 (로그인 필요)",
+            content =
+            @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ApiResponse.class),
+                examples =
+                @ExampleObject(
+                    name = "인증 실패 예시",
+                    value =
+                        """
+                        {
+                          "code": "40100",
+                          "message": "인증이 필요합니다",
+                          "data": null
+                        }
+                        """))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404",
+            description = "유효하지 않은 매물 ID",
+            content =
+            @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ApiResponse.class),
+                examples =
+                @ExampleObject(
+                    name = "매물 없음 예시",
+                    value =
+                        """
+                        {
+                          "code": "71000",
+                          "message": "유효하지 않은 매물입니다",
+                          "data": null
+                        }
+                        """)))
+    })
+    @GetMapping("/sharelink/{propertyId}")
+    ResponseEntity<ApiResponse<SharePropertyResponse>> getShareLink(
+        @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipalDto userDetails,
+        @PathVariable("propertyId") Long propertyId);
 }

--- a/src/main/java/com/example/dnd_13th_9_be/property/presentation/docs/PropertyShareDocs.java
+++ b/src/main/java/com/example/dnd_13th_9_be/property/presentation/docs/PropertyShareDocs.java
@@ -1,0 +1,152 @@
+package com.example.dnd_13th_9_be.property.presentation.docs;
+
+import com.example.dnd_13th_9_be.global.response.ApiResponse;
+import com.example.dnd_13th_9_be.property.presentation.dto.response.PropertyDetailResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "매물 공유", description = "매물 공유(Property Share) 관련 API")
+public interface PropertyShareDocs {
+    @Operation(
+        summary = "매물 메모 공유 화면 데이터 조회",
+        description =
+            """
+            공유 토큰(shareLink)으로 매물 메모 상세 데이터를 조회합니다.
+            """)
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "성공",
+            content =
+            @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ApiResponse.class),
+                examples =
+                @ExampleObject(
+                    name = "성공 예시",
+                    value =
+                        """
+                        {
+                          "code": "20000",
+                          "message": "성공했습니다",
+                          "data": {
+                            "images": [
+                              { "imageId": 13, "url": "https://zipzip-bucket.s3.amazonaws.com/images/58be7686-3fcb-4655-b3aa-fe9e713c0ab7.jpeg", "order": 1 },
+                              { "imageId": 14, "url": "https://zipzip-bucket.s3.amazonaws.com/images/84a2ccc2-52c9-4f5f-b1b1-c7c37e926887.jpg", "order": 2 }
+                            ],
+                            "propertyId": 35,
+                            "planId": 3,
+                            "planName": "기본 계획",
+                            "folderId": 3,
+                            "folderName": "기본 폴더",
+                            "feeling": "BAD",
+                            "propertyName": "안 괜찮은 원룸",
+                            "memo": "이 집은 될 수 있으면 피할 것!",
+                            "referenceUrl": null,
+                            "address": "경상북도 울진군",
+                            "detailAddress": "앞마당",
+                            "longitude": 128.981411608042,
+                            "latitude": 35.098237529977,
+                            "contractType": "JEONSE",
+                            "houseType": "ETC",
+                            "depositBig": 1,
+                            "depositSmall": 2,
+                            "managementFee": null,
+                            "moveInInfo": "30일 지나서",
+                            "checklist": {
+                              "categories": [
+                                { "order": 0, "name": "필수 확인" },
+                                { "order": 1, "name": "메인 공간" },
+                                { "order": 2, "name": "창문" },
+                                { "order": 3, "name": "욕실" },
+                                { "order": 4, "name": "건물" }
+                              ],
+                              "sections": [
+                                {
+                                  "categoryId": 0,
+                                  "categoryName": "필수 확인",
+                                  "items": [
+                                    { "itemId": 1, "question": "너무 노후화되진 않았나요?" },
+                                    { "itemId": 21, "question": "건물에 악취나 벌레가 있을만한 가게가 있나요?" }
+                                  ]
+                                },
+                                {
+                                  "categoryId": 4,
+                                  "categoryName": "메인 공간",
+                                  "items": [
+                                    { "itemId": 2, "question": "전체적으로 깔끔한 편인가요?", "description": "벽지와 장판 오염이 많을 경우 도배 가능한지 문의하세요" },
+                                    { "itemId": 3, "question": "체감 면적은 넓은가요?" },
+                                    { "itemId": 4, "question": "벌레 출몰 위험은 없나요?", "description": "주방에 까만 점이 있거나, 약을 둔 흔적이 있나요?" },
+                                    { "itemId": 5, "question": "벽간 소음은 괜찮은가요?", "description": "벽을 두드렸을 때, '통통' 소리가 난다면 주의하세요" },
+                                    { "itemId": 6, "question": "가구 옵션 구성과 상태는 어떤가요?", "description": "수리나 청소가 필요한지 꼼꼼하게 살펴보세요" },
+                                    { "itemId": 7, "question": "인터넷이 설치되어 있나요?", "description": "휴대폰도 잘 터지는지 확인하세요" }
+                                  ]
+                                },
+                                {
+                                  "categoryId": 1,
+                                  "categoryName": "창문",
+                                  "memo": "메인 공간 메모입니다",
+                                  "items": [
+                                    { "itemId": 8, "question": "바람이 잘 통하나요?" },
+                                    { "itemId": 9, "question": "햇빛이 잘 드나요?", "description": "남향 > 남동향 > 동향 > 남서향 > 서향 > 북향" },
+                                    { "itemId": 10, "question": "뷰는 괜찮은가요?", "description": "다른 건물과 너무 가깝지는 않은지 확인하세요!" }
+                                  ]
+                                },
+                                {
+                                  "categoryId": 2,
+                                  "categoryName": "욕실",
+                                  "memo": "추가된 메모 입니다",
+                                  "items": [
+                                    { "itemId": 11, "question": "배수구 악취는 없나요?", "description": "화장실 환풍기와 창문 여부를 확인하세요" },
+                                    { "itemId": 12, "question": "온수가 잘 나오나요?", "description": "보일러 연식이 10년 이상이면 온수·가스비를 주의하세요" },
+                                    { "itemId": 13, "question": "수압이 좋은 집인가요?", "description": "세면대, 샤워기를 틀어 놓고 변기 물을 내려보세요" },
+                                    { "itemId": 14, "question": "배수 상태는 괜찮은가요?", "description": "물 받아두고 다시 빼보세요" }
+                                  ]
+                                },
+                                {
+                                  "categoryId": 3,
+                                  "categoryName": "건물",
+                                  "items": [
+                                    { "itemId": 15, "question": "층수는 어떻게 되나요?" },
+                                    { "itemId": 16, "question": "엘레베이터는 있나요?" },
+                                    { "itemId": 22, "question": "소음 발생 가능성은 없나요?", "description": "대로변에 위치하거나 인근에 공사장이 있나요?" },
+                                    { "itemId": 23, "question": "보안 상태는 괜찮은가요?", "description": "도어락·방범창 상태와 CCTV 위치를 확인하세요" },
+                                    { "itemId": 17, "question": "담배나 찌든 냄새 등 악취가 있진 않나요?" },
+                                    { "itemId": 18, "question": "주차 공간이 있나요?" },
+                                    { "itemId": 19, "question": "가파른 언덕에 있지는 않나요?" },
+                                    { "itemId": 20, "question": "인근에 편의시설이 잘 갖춰져 있나요?", "description": "편의점, 코인빨래방 등이 가까운 곳에 있나요?" }
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                        """))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "500",
+            description = "복호화 실패 (유효하지 않은 공유 토큰)",
+            content =
+            @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = ApiResponse.class),
+                examples =
+                @ExampleObject(
+                    name = "복호화 실패 예시",
+                    value =
+                        """
+                        {
+                          "code": "51001",
+                          "message": "복호화에 실패했습니다",
+                          "data": null
+                        }
+                        """)))
+    })
+    ResponseEntity<ApiResponse<PropertyDetailResponse>> getProperty(
+        @PathVariable("shareLink") String shareLink);
+}

--- a/src/main/java/com/example/dnd_13th_9_be/property/presentation/dto/request/SharePropertyRequest.java
+++ b/src/main/java/com/example/dnd_13th_9_be/property/presentation/dto/request/SharePropertyRequest.java
@@ -1,3 +1,6 @@
 package com.example.dnd_13th_9_be.property.presentation.dto.request;
 
-public record SharePropertyRequest(String userId, String propertyId) {}
+import lombok.Builder;
+
+@Builder
+public record SharePropertyRequest(Long userId, Long propertyId) {}

--- a/src/main/java/com/example/dnd_13th_9_be/property/presentation/dto/request/SharePropertyRequest.java
+++ b/src/main/java/com/example/dnd_13th_9_be/property/presentation/dto/request/SharePropertyRequest.java
@@ -1,0 +1,3 @@
+package com.example.dnd_13th_9_be.property.presentation.dto.request;
+
+public record SharePropertyRequest(String userId, String propertyId) {}

--- a/src/main/java/com/example/dnd_13th_9_be/property/presentation/dto/response/SharePropertyResponse.java
+++ b/src/main/java/com/example/dnd_13th_9_be/property/presentation/dto/response/SharePropertyResponse.java
@@ -1,0 +1,3 @@
+package com.example.dnd_13th_9_be.property.presentation.dto.response;
+
+public record SharePropertyResponse(String shareLink) {}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -63,3 +63,6 @@ logging:
     org.springframework.security.oauth2: DEBUG
     org.springframework.web.client.RestTemplate: DEBUG
     com.example.dnd_13th_9_be: DEBUG
+
+aes:
+  private-key: ${AES_PRIVATE_KEY}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -61,3 +61,6 @@ logging:
     org.springframework.security.oauth2: INFO
     org.springframework.web.client.RestTemplate: INFO
     com.example.dnd_13th_9_be: INFO
+
+aes:
+  private-key: ${AES_PRIVATE_KEY}


### PR DESCRIPTION
### 주요 변경사항
closes #76 
- 사용자가 작성한 매물 메모를 공유할 수 있는 기능을 추가했습니다
- 임시로 공유하기 기능 구현을 위해 매물 메모 조회시 사용되는 값을 암호화하여 클라이언트로 전달하는 로직을 작성했습니다
- 기간 내에 구현하기 위해 이번에 보안에 취약한 임시 api를 구축하고 추후 리팩토링 하기로 이야기 되었습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Generate encrypted share links for properties and retrieve property details via a public share URL (no authentication required for GET share links).

- **Improvements**
  - Clearer error handling and consistent responses for encryption, decryption, and JSON processing failures.

- **Chores**
  - Added AES private-key configuration for dev and prod environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->