### PR TITLE
[FIX] 체크리스트 목록 API 

### DIFF
--- a/src/main/java/com/example/dnd_13th_9_be/checklist/presentation/dto/ChecklistResponse.java
+++ b/src/main/java/com/example/dnd_13th_9_be/checklist/presentation/dto/ChecklistResponse.java
@@ -2,11 +2,10 @@ package com.example.dnd_13th_9_be.checklist.presentation.dto;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import com.example.dnd_13th_9_be.checklist.application.model.ChecklistCategoryModel;
+import com.example.dnd_13th_9_be.checklist.application.model.ChecklistItemModel;
 
 public record ChecklistResponse(List<CategorySummary> categories, List<Section> sections) {
   static final String REQUIRED_CHECK = "필수 확인";
@@ -16,20 +15,26 @@ public record ChecklistResponse(List<CategorySummary> categories, List<Section> 
     List<CategorySummary> categorySummaries = new ArrayList<>();
     categorySummaries.add(new CategorySummary(0, REQUIRED_CHECK));
 
-    List<SectionItem> requiredSectionItems = new ArrayList<>();
     List<Section> sections = new ArrayList<>();
 
     for (ChecklistCategoryModel category : categories) {
       categorySummaries.add(new CategorySummary(category.getSortOrder(), category.getName()));
-      Map<Boolean, List<SectionItem>> partitionedItems =
-          category.getItems().stream()
-              .map(item -> new SectionItem(item.getId(), item.getQuestion(), item.getDescription()))
-              .collect(Collectors.partitioningBy(item -> requiredIds.contains(item.itemId())));
-      requiredSectionItems.addAll(partitionedItems.get(true));
-      sections.add(
-          new Section(category.getId(), category.getName(), null, partitionedItems.get(false)));
+      List<SectionItem> items = new ArrayList<>();
+      for (ChecklistItemModel item : category.getItems()) {
+        SectionItem sectionItem =
+            new SectionItem(
+                item.getId(),
+                item.getQuestion(),
+                item.getDescription(),
+                requiredIds.contains(item.getId()));
+        items.add(sectionItem);
+      }
+      Section section = new Section(category.getId(), category.getName(), null, items);
+      sections.add(section);
     }
-    sections.addFirst(new Section(0L, REQUIRED_CHECK, null, requiredSectionItems));
+
+    // TODO: 의미는 없지만 시간상 프론트에서 구조 변경이 어려워 구조 맞추기 위한 용도로 추가, 추후 구조 개선 필요
+    sections.addFirst(new Section(0L, REQUIRED_CHECK, null, new ArrayList<>()));
 
     return new ChecklistResponse(categorySummaries, sections);
   }

--- a/src/main/java/com/example/dnd_13th_9_be/checklist/presentation/dto/SectionItem.java
+++ b/src/main/java/com/example/dnd_13th_9_be/checklist/presentation/dto/SectionItem.java
@@ -4,4 +4,4 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 @JsonInclude(Include.NON_NULL)
-public record SectionItem(Long itemId, String question, String description) {}
+public record SectionItem(Long itemId, String question, String description, boolean isFill) {}

--- a/src/main/java/com/example/dnd_13th_9_be/property/presentation/PropertyShareController.java
+++ b/src/main/java/com/example/dnd_13th_9_be/property/presentation/PropertyShareController.java
@@ -1,6 +1,5 @@
 package com.example.dnd_13th_9_be.property.presentation;
 
-import com.example.dnd_13th_9_be.property.presentation.docs.PropertyShareDocs;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,6 +13,7 @@ import com.example.dnd_13th_9_be.common.cipher.AESCipherUtil;
 import com.example.dnd_13th_9_be.common.utils.JsonUtil;
 import com.example.dnd_13th_9_be.global.response.ApiResponse;
 import com.example.dnd_13th_9_be.property.application.PropertyService;
+import com.example.dnd_13th_9_be.property.presentation.docs.PropertyShareDocs;
 import com.example.dnd_13th_9_be.property.presentation.dto.request.SharePropertyRequest;
 import com.example.dnd_13th_9_be.property.presentation.dto.response.PropertyDetailResponse;
 

--- a/src/main/java/com/example/dnd_13th_9_be/property/presentation/docs/PropertyDocs.java
+++ b/src/main/java/com/example/dnd_13th_9_be/property/presentation/docs/PropertyDocs.java
@@ -1,6 +1,5 @@
 package com.example.dnd_13th_9_be.property.presentation.docs;
 
-import com.example.dnd_13th_9_be.property.presentation.dto.response.SharePropertyResponse;
 import java.util.List;
 import java.util.Map;
 
@@ -21,6 +20,7 @@ import com.example.dnd_13th_9_be.property.application.model.RecentPropertyModel;
 import com.example.dnd_13th_9_be.property.presentation.dto.request.UpsertPropertyRequest;
 import com.example.dnd_13th_9_be.property.presentation.dto.response.PropertyCreateResponse;
 import com.example.dnd_13th_9_be.property.presentation.dto.response.PropertyDetailResponse;
+import com.example.dnd_13th_9_be.property.presentation.dto.response.SharePropertyResponse;
 import com.example.dnd_13th_9_be.user.application.dto.UserPrincipalDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -551,29 +551,29 @@ public interface PropertyDocs {
           @RequestParam(name = "size", defaultValue = "10")
           int size);
 
-    @Operation(
-        summary = "매물 공유 링크 생성",
-        description =
-            """
+  @Operation(
+      summary = "매물 공유 링크 생성",
+      description =
+          """
                 1. `/api/property/sharelink/{propertyId}` api를 호출해서 응답의 `shareLink`라는 토큰 값을 얻습니다.
                 2. 클라이언트는 로그인 하지 않은 사용자에게 매물 메모를 보여줄 화면 url을 가지고 있을 겁니다. 이 url과 sharedLink 토큰을 조합하여 사용자에게 공유합니다. (ex: 만약 매물 메모 공유 화면 링크가 [www.zipzip.cloud/share/property](http://www.zipzip.cloud/share/property) 일경우 www.zipzip.cloud/share/property/{shareLink} 와 같은 url을 사용자에게 전달합니다. 이 부분은 클라이언트 부분이므로 프론트에서 작업하시기 편리한 방법을 선택하시면 됩니다.)
                 3. 로그인 하지 않은 사용자는 매물 메모 공유 링크를 가지고 해당 웹페이지로 접근합니다.
                 4. 클라이언트는 사용자가 접속한 링크에서 sharedLink 부분을 얻어, `/api/property/share/{shareLink}` api로 전달 주세요. 해당 api문서는 [매물 메모 공유 화면 데이터 조회](https://www.notion.so/25cb87ed31df80a39b20c7f5ce6af65f?pvs=21) 입니다.
                 5. 매물 메모 공유 테스트 할때는 access 토큰과 refresh 토큰 없이 확인해 주세요!
             """)
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200",
-            description = "성공 (공유 토큰 발급)",
-            content =
+  @ApiResponses({
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "200",
+        description = "성공 (공유 토큰 발급)",
+        content =
             @Content(
                 mediaType = "application/json",
                 schema = @Schema(implementation = ApiResponse.class),
                 examples =
-                @ExampleObject(
-                    name = "성공 예시",
-                    value =
-                        """
+                    @ExampleObject(
+                        name = "성공 예시",
+                        value =
+                            """
                         {
                           "code": "20000",
                           "message": "성공했습니다",
@@ -582,45 +582,45 @@ public interface PropertyDocs {
                           }
                         }
                         """))),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "401",
-            description = "인증 실패 (로그인 필요)",
-            content =
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "401",
+        description = "인증 실패 (로그인 필요)",
+        content =
             @Content(
                 mediaType = "application/json",
                 schema = @Schema(implementation = ApiResponse.class),
                 examples =
-                @ExampleObject(
-                    name = "인증 실패 예시",
-                    value =
-                        """
+                    @ExampleObject(
+                        name = "인증 실패 예시",
+                        value =
+                            """
                         {
                           "code": "40100",
                           "message": "인증이 필요합니다",
                           "data": null
                         }
                         """))),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "404",
-            description = "유효하지 않은 매물 ID",
-            content =
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "404",
+        description = "유효하지 않은 매물 ID",
+        content =
             @Content(
                 mediaType = "application/json",
                 schema = @Schema(implementation = ApiResponse.class),
                 examples =
-                @ExampleObject(
-                    name = "매물 없음 예시",
-                    value =
-                        """
+                    @ExampleObject(
+                        name = "매물 없음 예시",
+                        value =
+                            """
                         {
                           "code": "71000",
                           "message": "유효하지 않은 매물입니다",
                           "data": null
                         }
                         """)))
-    })
-    @GetMapping("/sharelink/{propertyId}")
-    ResponseEntity<ApiResponse<SharePropertyResponse>> getShareLink(
-        @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipalDto userDetails,
-        @PathVariable("propertyId") Long propertyId);
+  })
+  @GetMapping("/sharelink/{propertyId}")
+  ResponseEntity<ApiResponse<SharePropertyResponse>> getShareLink(
+      @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipalDto userDetails,
+      @PathVariable("propertyId") Long propertyId);
 }

--- a/src/main/java/com/example/dnd_13th_9_be/property/presentation/docs/PropertyShareDocs.java
+++ b/src/main/java/com/example/dnd_13th_9_be/property/presentation/docs/PropertyShareDocs.java
@@ -1,5 +1,8 @@
 package com.example.dnd_13th_9_be.property.presentation.docs;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
 import com.example.dnd_13th_9_be.global.response.ApiResponse;
 import com.example.dnd_13th_9_be.property.presentation.dto.response.PropertyDetailResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -8,30 +11,27 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "매물 공유", description = "매물 공유(Property Share) 관련 API")
 public interface PropertyShareDocs {
-    @Operation(
-        summary = "매물 메모 공유 화면 데이터 조회",
-        description =
-            """
+  @Operation(
+      summary = "매물 메모 공유 화면 데이터 조회",
+      description = """
             공유 토큰(shareLink)으로 매물 메모 상세 데이터를 조회합니다.
             """)
-    @ApiResponses({
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200",
-            description = "성공",
-            content =
+  @ApiResponses({
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "200",
+        description = "성공",
+        content =
             @Content(
                 mediaType = "application/json",
                 schema = @Schema(implementation = ApiResponse.class),
                 examples =
-                @ExampleObject(
-                    name = "성공 예시",
-                    value =
-                        """
+                    @ExampleObject(
+                        name = "성공 예시",
+                        value =
+                            """
                         {
                           "code": "20000",
                           "message": "성공했습니다",
@@ -128,25 +128,25 @@ public interface PropertyShareDocs {
                           }
                         }
                         """))),
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "500",
-            description = "복호화 실패 (유효하지 않은 공유 토큰)",
-            content =
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "500",
+        description = "복호화 실패 (유효하지 않은 공유 토큰)",
+        content =
             @Content(
                 mediaType = "application/json",
                 schema = @Schema(implementation = ApiResponse.class),
                 examples =
-                @ExampleObject(
-                    name = "복호화 실패 예시",
-                    value =
-                        """
+                    @ExampleObject(
+                        name = "복호화 실패 예시",
+                        value =
+                            """
                         {
                           "code": "51001",
                           "message": "복호화에 실패했습니다",
                           "data": null
                         }
                         """)))
-    })
-    ResponseEntity<ApiResponse<PropertyDetailResponse>> getProperty(
-        @PathVariable("shareLink") String shareLink);
+  })
+  ResponseEntity<ApiResponse<PropertyDetailResponse>> getProperty(
+      @PathVariable("shareLink") String shareLink);
 }


### PR DESCRIPTION
## 작업내용
closes #82 
- 클라이언트 측에서 `isFill` 값을 확인하여 필수 확인 여부에 따라 UI를 구성합니다
- 필수 확인 해제시 기존에는 어떤 카테고리에 포함되었는지 알 수 없었지만 원본 체크리스트 목록을 제공하여 해당 문제를 해소했습니다

## 리뷰어 공유사항
- 현재 클라이언트에서 구조 변경이 어려워 빈 items 배열을 가진 필수 확인 section을 응답으로 보내고 있습니다. 추후 클라이언트와 백엔드 모두 구조 개선이 필요합니다

## Screenshot
<img width="450" height="179" alt="스크린샷 2025-08-28 오후 11 23 34" src="https://github.com/user-attachments/assets/641d662f-9834-4874-85a6-6c23d174f8f4" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Checklist items now include a fill/required indicator for clearer guidance.
  - Sections are consolidated to show all items together, each marked with its requirement status.
  - Added a top “Required Check” section (may be empty) for UI consistency.

- Documentation
  - Refreshed property share API documentation formatting and examples without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->