### PR TITLE
[REFACTOR] 운영용, 개발용 쿠키 분기 처리

### DIFF
--- a/src/main/java/com/example/dnd_13th_9_be/common/utils/CookieUtil.java
+++ b/src/main/java/com/example/dnd_13th_9_be/common/utils/CookieUtil.java
@@ -26,19 +26,18 @@ public class CookieUtil {
   public Cookie create(String key, String value, long expirationMs) {
     Cookie cookie = new Cookie(key, value);
     cookie.setMaxAge((int) (expirationMs / 1000)); // 초 단위로 변환
-    cookie.setPath("/");
-    cookie.setHttpOnly(true);
-    cookie.setSecure(secure);
-    cookie.setAttribute("SameSite", sameSite);
-    if(!domain.isEmpty()){
-      cookie.setDomain(domain);
-    }
+    configureCookie(cookie);
     return cookie;
   }
 
   public Cookie remove(String key) {
     Cookie cookie = new Cookie(key, null);
     cookie.setMaxAge(0);
+    configureCookie(cookie);
+    return cookie;
+  }
+
+  private void configureCookie(Cookie cookie){
     cookie.setPath("/");
     cookie.setHttpOnly(true);
     cookie.setSecure(secure);
@@ -46,7 +45,6 @@ public class CookieUtil {
     if(!domain.isEmpty()){
       cookie.setDomain(domain);
     }
-    return cookie;
   }
 
   public Optional<Cookie> find(Cookie[] cookies, String key) {

--- a/src/main/java/com/example/dnd_13th_9_be/common/utils/CookieUtil.java
+++ b/src/main/java/com/example/dnd_13th_9_be/common/utils/CookieUtil.java
@@ -37,12 +37,12 @@ public class CookieUtil {
     return cookie;
   }
 
-  private void configureCookie(Cookie cookie){
+  private void configureCookie(Cookie cookie) {
     cookie.setPath("/");
     cookie.setHttpOnly(true);
     cookie.setSecure(secure);
     cookie.setAttribute("SameSite", sameSite);
-    if(!domain.isEmpty()){
+    if (!domain.isEmpty()) {
       cookie.setDomain(domain);
     }
   }
@@ -50,7 +50,7 @@ public class CookieUtil {
   public Optional<Cookie> find(Cookie[] cookies, String key) {
     if (cookies == null || cookies.length == 0) return Optional.empty();
     return Arrays.stream(cookies)
-            .filter(cookie -> Objects.equals(key, cookie.getName()))
-            .findFirst();
+        .filter(cookie -> Objects.equals(key, cookie.getName()))
+        .findFirst();
   }
 }

--- a/src/main/java/com/example/dnd_13th_9_be/common/utils/CookieUtil.java
+++ b/src/main/java/com/example/dnd_13th_9_be/common/utils/CookieUtil.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import java.util.Optional;
 import jakarta.servlet.http.Cookie;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
@@ -13,14 +14,25 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CookieUtil {
 
+  @Value("${cookie.secure:false}")
+  private boolean secure;
+
+  @Value("${cookie.same-site:Lax}")
+  private String sameSite;
+
+  @Value("${cookie.domain:}")
+  private String domain;
+
   public Cookie create(String key, String value, long expirationMs) {
     Cookie cookie = new Cookie(key, value);
     cookie.setMaxAge((int) (expirationMs / 1000)); // 초 단위로 변환
     cookie.setPath("/");
-    cookie.setHttpOnly(false);
-    cookie.setSecure(true); // TODO: https 적용후 true
-    cookie.setAttribute("SameSite", "None");
-    cookie.setDomain("zipzip.cloud");
+    cookie.setHttpOnly(true);
+    cookie.setSecure(secure);
+    cookie.setAttribute("SameSite", sameSite);
+    if(!domain.isEmpty()){
+      cookie.setDomain(domain);
+    }
     return cookie;
   }
 
@@ -28,17 +40,19 @@ public class CookieUtil {
     Cookie cookie = new Cookie(key, null);
     cookie.setMaxAge(0);
     cookie.setPath("/");
-    cookie.setHttpOnly(false);
-    cookie.setSecure(true); // TODO: https 적용후 true
-    cookie.setAttribute("SameSite", "None");
-    cookie.setDomain("zipzip.cloud");
+    cookie.setHttpOnly(true);
+    cookie.setSecure(secure);
+    cookie.setAttribute("SameSite", sameSite);
+    if(!domain.isEmpty()){
+      cookie.setDomain(domain);
+    }
     return cookie;
   }
 
   public Optional<Cookie> find(Cookie[] cookies, String key) {
     if (cookies == null || cookies.length == 0) return Optional.empty();
     return Arrays.stream(cookies)
-        .filter(cookie -> Objects.equals(key, cookie.getName()))
-        .findFirst();
+            .filter(cookie -> Objects.equals(key, cookie.getName()))
+            .findFirst();
   }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -66,3 +66,8 @@ logging:
 
 aes:
   private-key: ${AES_PRIVATE_KEY}
+
+cookie:
+  secure: false
+  same-site: Lax
+  domain: ""

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -64,3 +64,8 @@ logging:
 
 aes:
   private-key: ${AES_PRIVATE_KEY}
+
+cookie:
+  secure: true
+  same-site: None
+  domain: "zipzip.cloud"


### PR DESCRIPTION
### 주요 변경사항
closes #94 
- 운영용, 개발용 쿠키 설정이 달라 환경에 따라 수동으로 설정해주어야하는 불편함이 있었습니다
- 운영용, 개발용 쿠키 설정을 분기처리하여 실행 환경에 따라 변경되도록 리팩토링하였습니다.
- application prod : https 설정, same site, secure설정
- application dev : http에서도 쿠키를 담을 수 있도록 설정해두었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Cookies are now HttpOnly by default for enhanced protection.
  - Cookie attributes (Secure, SameSite, Domain) are configurable per environment to improve compatibility and deployment flexibility.

- Chores
  - Added environment-specific cookie settings:
    - Development: Secure disabled, SameSite=Lax, no domain.
    - Production: Secure enabled, SameSite=None, domain set to the live hostname.

- Refactor
  - Standardized cookie creation/removal to use configuration-driven attributes for consistent behavior across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->